### PR TITLE
Update orchestrator plugin to communicate with Data-Index service

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/sonataflows.yaml
+++ b/charts/orchestrator/templates/sonataflows.yaml
@@ -127,7 +127,7 @@ metadata:
   annotations:
     sonataflow.org/description: YAML based greeting workflow
     sonataflow.org/expressionLang: jsonpath
-    sonataflow.org/profile: dev
+    sonataflow.org/profile: prod
     sonataflow.org/version: "1.0"
   creationTimestamp: null
   labels:

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -5,7 +5,7 @@ sonataFlowOperator:
     channel: alpha # channel of an operator package to subscribe to
     installPlanApproval: Automatic # whether the update should be installed automatically
     pkgName: sonataflow-operator # name of the operator package
-    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-service-labels # catalog image of the development build. Unset it for the release build.
+    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-snapshot # catalog image of the development build. Unset it for the release build.
     sourceNamespace: openshift-marketplace # namespace of the catalog source
     source: sonataflow-operator # name of the catalog source for the operator
 
@@ -36,8 +36,8 @@ backstage:
       plugins:
         - disabled: false
           integrity: >-
-            sha512-IWXacpKwDPGA5dVmQz2R0au2yGVsNj7dSwbZVWwSkjkMowN1PtUNDDF2I69w5CKLa6LEO7ByswdEj5moh046Bg==
-          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.6"
+            sha512-rcC7HxmwrkapXfZP/IisDcPXm9EDbyMFRFvI5tb6LEAfs0Kz3g0xyEz7vg6J/7G+utDF6lN67IhxrhV+FKxd4g==
+          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.8"
           pluginConfig:
             orchestrator:
               dataIndexService:
@@ -46,8 +46,8 @@ backstage:
                 path: "https://sandbox.kie.org/swf-chrome-extension/0.32.0"
         - disabled: false
           integrity: >-
-            sha512-VqQK+CuqGDUWdFdIPVO8OcrMjbmhdQeZMfEnDftS7j7LyNQoqirDB8r0H9GQSoaKVhJ8adC008Zd6t9b4GLrNw==
-          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.6"
+            sha512-bEao8SgVeKJ7oPOW16OwhPYls2Qo+hLChEh23FJ76CZFjCgmzhfpnv4DR/AcxjLnLgWXJkS3B0lpZeTUzlwgqg==
+          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.8"
           pluginConfig:
             dynamicPlugins:
               frontend:
@@ -117,4 +117,4 @@ orchestrator:
         cpu: "500m"
   sonataflows: # workflows to get deployed - this option will be removed once the plugin will interact directly with the data-index
     - name: greeting
-      image: quay.io/masayag/serverless-workflow-greeting:latest
+      image: quay.io/orchestrator/serverless-workflow-greeting:latest

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -36,8 +36,8 @@ backstage:
       plugins:
         - disabled: false
           integrity: >-
-            sha512-rcC7HxmwrkapXfZP/IisDcPXm9EDbyMFRFvI5tb6LEAfs0Kz3g0xyEz7vg6J/7G+utDF6lN67IhxrhV+FKxd4g==
-          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.8"
+            sha512-XxSVZetbVh7afEyFvDk9l3FIAcul/r0NjBoNpvaqOBxxd0GPuYfxpVgipSoIwqw0NkW1opaMtMp18unTMchN+Q==
+          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.9"
           pluginConfig:
             orchestrator:
               dataIndexService:
@@ -46,8 +46,8 @@ backstage:
                 path: "https://sandbox.kie.org/swf-chrome-extension/0.32.0"
         - disabled: false
           integrity: >-
-            sha512-bEao8SgVeKJ7oPOW16OwhPYls2Qo+hLChEh23FJ76CZFjCgmzhfpnv4DR/AcxjLnLgWXJkS3B0lpZeTUzlwgqg==
-          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.8"
+            sha512-5anu/WsUjW9A1eSvvRAbxWJXP6kOUpUvhtPNPJ9in5a5DE+77lCYc8x3gVU67InsGwpgJvoFcnZ08cPQbzCIwQ==
+          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.9"
           pluginConfig:
             dynamicPlugins:
               frontend:

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -5,7 +5,7 @@ sonataFlowOperator:
     channel: alpha # channel of an operator package to subscribe to
     installPlanApproval: Automatic # whether the update should be installed automatically
     pkgName: sonataflow-operator # name of the operator package
-    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-labels # catalog image of the development build. Unset it for the release build.
+    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-service-labels # catalog image of the development build. Unset it for the release build.
     sourceNamespace: openshift-marketplace # namespace of the catalog source
     source: sonataflow-operator # name of the catalog source for the operator
 
@@ -36,21 +36,18 @@ backstage:
       plugins:
         - disabled: false
           integrity: >-
-            sha512-PO+rs/qYLYUR0jEsLPEdO0pgCKZDtrm2qlPHb73jocOf6+81lnYjbNdV4nKi/XjRIQvr7BB0yTW3zg80nb8ToQ==
-          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.6-alpha3"
+            sha512-IWXacpKwDPGA5dVmQz2R0au2yGVsNj7dSwbZVWwSkjkMowN1PtUNDDF2I69w5CKLa6LEO7ByswdEj5moh046Bg==
+          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.6"
           pluginConfig:
             orchestrator:
-              sonataFlowService:
-                # this value will be replaced with a link to the data-index service once supported by the plugin and the operator
-                baseUrl: http://greeting.sonataflow-infra
-                port: 80
-                path: /
+              dataIndexService:
+                url: http://sonataflow-platform-data-index-service.sonataflow-infra
               editor:
                 path: "https://sandbox.kie.org/swf-chrome-extension/0.32.0"
         - disabled: false
           integrity: >-
-            sha512-RANTNf1A/V/lY6sy3M1c7Gl7c3MJkzsqjpgygCtdVgaMHHbQ02oVkyGdgAzFEiYb6LUqmM/ei6XrRoXXTz/KNA==
-          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.6-alpha3"
+            sha512-VqQK+CuqGDUWdFdIPVO8OcrMjbmhdQeZMfEnDftS7j7LyNQoqirDB8r0H9GQSoaKVhJ8adC008Zd6t9b4GLrNw==
+          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.6"
           pluginConfig:
             dynamicPlugins:
               frontend:

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -5,7 +5,7 @@ sonataFlowOperator:
     channel: alpha # channel of an operator package to subscribe to
     installPlanApproval: Automatic # whether the update should be installed automatically
     pkgName: sonataflow-operator # name of the operator package
-    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-snapshot # catalog image of the development build. Unset it for the release build.
+    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-props # catalog image of the development build. Unset it for the release build.
     sourceNamespace: openshift-marketplace # namespace of the catalog source
     source: sonataflow-operator # name of the catalog source for the operator
 

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -5,7 +5,7 @@ sonataFlowOperator:
     channel: alpha # channel of an operator package to subscribe to
     installPlanApproval: Automatic # whether the update should be installed automatically
     pkgName: sonataflow-operator # name of the operator package
-    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-props # catalog image of the development build. Unset it for the release build.
+    sourceImage: quay.io/masayag/kogito-serverless-operator-catalog:v2.0.0-snapshot # catalog image of the development build. Unset it for the release build.
     sourceNamespace: openshift-marketplace # namespace of the catalog source
     source: sonataflow-operator # name of the catalog source for the operator
 
@@ -36,8 +36,8 @@ backstage:
       plugins:
         - disabled: false
           integrity: >-
-            sha512-XxSVZetbVh7afEyFvDk9l3FIAcul/r0NjBoNpvaqOBxxd0GPuYfxpVgipSoIwqw0NkW1opaMtMp18unTMchN+Q==
-          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.9"
+            sha512-xwLJA197QiblD4ziBGP6W7Lf7VOStdyNLc+MmIarYu54ivaUh5nhucw1bLTub1jjvgIJ/2fwcmhP8lGXI79pSg==
+          package: "@caponetto-tests/backstage-plugin-orchestrator-backend-dynamic@0.0.10"
           pluginConfig:
             orchestrator:
               dataIndexService:
@@ -46,8 +46,8 @@ backstage:
                 path: "https://sandbox.kie.org/swf-chrome-extension/0.32.0"
         - disabled: false
           integrity: >-
-            sha512-5anu/WsUjW9A1eSvvRAbxWJXP6kOUpUvhtPNPJ9in5a5DE+77lCYc8x3gVU67InsGwpgJvoFcnZ08cPQbzCIwQ==
-          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.9"
+            sha512-7Wur8JlvVCPG9afbcTp3Cy/BLnFtep+NoL4Z6cCbeeM1MSinhT1QP+kppuu5St8LdXCShfm2WsPDaxq/mWxAtA==
+          package: "@caponetto-tests/backstage-plugin-orchestrator@0.0.10"
           pluginConfig:
             dynamicPlugins:
               frontend:


### PR DESCRIPTION
With version 0.0.8 of the backstage orchestrator plugins, we can now communicate with the platform's data-index service. This will enable to deploy and support multiple sonataflow workflows at the same time.

This issue requires a version of the operator with https://issues.redhat.com/browse/KOGITO-9888 fixed.
Instead, the sonataflow-operator is built with this hack: https://github.com/masayag/kogito-serverless-operator/pull/new/hack_enable_di_props 