### PR TITLE
Use showcase image with notification plugin

### DIFF
--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -66,7 +66,7 @@ backstage:
   upstream:
     backstage:
       image:
-        tag: next
+        tag: pr-885
       appConfig:
         integrations:
           github:
@@ -95,6 +95,8 @@ backstage:
                 ]
           locations:
             - type: url
+              target: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/notifications-backend/users.yaml
+            - type: url
               target: https://github.com/parodos-dev/workflow-software-templates/blob/main/entities/workflow-resources.yaml
             - type: url
               target: https://github.com/parodos-dev/workflow-software-templates/blob/main/template/template.yaml
@@ -104,6 +106,13 @@ backstage:
           csp:
             frame-src:
               - "https://sandbox.kie.org"
+          database:
+            client: pg
+            connection:
+              password: ${POSTGRESQL_ADMIN_PASSWORD}
+              user: postgres
+              host: orchestrator-postgresql-hl.orchestrator.svc.cluster.local
+              port: 5432
 
 orchestrator:
   namespace: sonataflow-infra # namespace where the data index, job service and workflows are deployed


### PR DESCRIPTION
Deploy the janus-idp showcase based on quay.io/janus-idp/backstage-showcase:pr-885 image that was created by https://github.com/janus-idp/backstage-showcase/pull/885

Due to a bug in the notification plugin, the DB should be created manually by
```
CREATE DATABASE backstage_plugin_notifications;
GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_notifications TO postgres;
```