### PR TITLE
Set security context for M2K kfunc to remove warning

### DIFF
--- a/charts/move2kube/templates/03-knative-resources.yaml
+++ b/charts/move2kube/templates/03-knative-resources.yaml
@@ -83,11 +83,18 @@ spec:
               readOnly: true
               mountPath: "/home/jboss/.ssh/id_rsa.pub"
               subPath: id_rsa.pub
-
           readinessProbe:
             successThreshold: 1
             tcpSocket:
               port: 0
+          securityContext:
+            runAsUser: null
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
       volumes:
         - name: ssh-priv-key
           secret:

--- a/charts/move2kube/templates/03-knative-resources.yaml
+++ b/charts/move2kube/templates/03-knative-resources.yaml
@@ -52,7 +52,11 @@ spec:
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: true
-          securityContext:
+            runAsNonRoot: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           command: [ "sh", "-c", "cp /tmp/.ssh/id_rsa /etc/pre-install/. && chown 185 /etc/pre-install/id_rsa" ]
           volumeMounts:
             - name: ssh-priv-key


### PR DESCRIPTION
Set security context for M2K kfunc to remove warning:
```
→ helm install move2kube orchestrator/move2kube
W0118 15:15:53.768160  529897 warnings.go:70] Kubernetes default value is insecure, Knative may default this to secure in a future release: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation, spec.template.spec.containers[0].securityContext.capabilities, spec.template.spec.containers[0].securityContext.runAsNonRoot, spec.template.spec.containers[0].securityContext.seccompProfile, spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation, spec.template.spec.initContainers[0].securityContext.capabilities, spec.template.spec.initContainers[0].securityContext.runAsNonRoot, spec.template.spec.initContainers[0].securityContext.seccompProfile
NAME: move2kube
LAST DEPLOYED: Thu Jan 18 15:15:53 2024
NAMESPACE: orchestrator
```

Closes https://issues.redhat.com/browse/FLPATH-873