### PR TITLE
Bump janus-idp version to 2.12.5

### DIFF
--- a/charts/orchestrator/Chart.lock
+++ b/charts/orchestrator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: backstage
-  repository: https://janus-idp.github.io/helm-backstage
-  version: 2.12.1
-digest: sha256:ef07d6cadee4a3a7b4b565cf31515b872eaa765ab829f26e71813af1e9334779
-generated: "2024-01-24T13:20:18.310660694+02:00"
+  repository: https://janus-idp.io/helm-backstage
+  version: 2.12.5
+digest: sha256:8eafad0692d34ea817a95df553b498623ba4e4ff21fec3ee964128ef16ca5c81
+generated: "2024-02-04T10:53:44.203032955+02:00"

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,5 +29,5 @@ icon: https://raw.githubusercontent.com/parodos-dev/parodos-dev.github.io/main/a
 
 dependencies:
   - name: backstage
-    repository: https://janus-idp.github.io/helm-backstage
-    version: "2.12.1"
+    repository: https://janus-idp.io/helm-backstage
+    version: "2.12.5"

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -36,8 +36,8 @@ backstage:
       plugins:
         - disabled: false
           integrity: >-
-            sha512-9Y2Y0QashRJSwWYMW9npqzbO4NNEqno7p9BnKDMKydnygpV/vQJSh6NV1ALYwVa9P9fy59QLkdIQ0EBbFNzHbw==
-          package: "@janus-idp/backstage-plugin-orchestrator-backend-dynamic@1.1.0"
+            sha512-/ZQZI6bssyYT1D2+LW/pqpdIFJJXCW5RC0Ti49YdyminEbAYmjhjKxEHagKRaxwYhmCHbJezkuqrUAern/xcbA==
+          package: "@janus-idp/backstage-plugin-orchestrator-backend-dynamic@1.2.0"
           pluginConfig:
             orchestrator:
               dataIndexService:
@@ -46,8 +46,8 @@ backstage:
                 path: "https://sandbox.kie.org/swf-chrome-extension/0.32.0"
         - disabled: false
           integrity: >-
-            sha512-UrUUy6qlta4oRQg9r7EwkClls++a9FoL8zTM1xLW6bg4f1WQuohDhzdWfCfQtBxaBdjkRW/8jp38s2y4Oic8hQ==
-          package: "@janus-idp/backstage-plugin-orchestrator@1.2.0"
+            sha512-RjtUkE1JxzEQhFGgpEW3yCtdLTf6B+FvNAVhWC6xkETk7BwGz+RO8CeDUVyXwuf6OJg1w347gZIjV64naqA+UA==
+          package: "@janus-idp/backstage-plugin-orchestrator@1.3.0"
           pluginConfig:
             dynamicPlugins:
               frontend:


### PR DESCRIPTION
Also, bump orchestrator plugin versions to the latest.
The sonataflow-serverless operator is also updated to the latest.