### PR TITLE
Update Janus IDP catalogsource version

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.35
+version: 0.1.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -34,7 +34,7 @@ rhdhOperator:
     pkgName: backstage-operator # name of the operator package
     # sourceImage: quay.io/rhdh/iib:latest-v4.{minorVersion}-x86_64 # catalog image of the development build. Unset it for the release build. Valid for 14 days.
     # ehdh image requires rhdh-operator namespace instead of backstage-system
-    sourceImage: quay.io/janus-idp/operator-catalog:0.1.0
+    sourceImage: quay.io/janus-idp/operator-catalog:0.2.0
     sourceNamespace: openshift-marketplace # namespace of the catalog source
     source: rhdh-operator # name of the catalog source for the operator
 


### PR DESCRIPTION
`quay.io/janus-idp/operator-catalog:0.1.0` is no longer with us.
moving to `quay.io/janus-idp/operator-catalog:0.2.0`