### PR TITLE
FLPATH-1134

### DIFF
--- a/GitOps.md
+++ b/GitOps.md
@@ -1,0 +1,65 @@
+# Initialize the GitOps environment
+## Install the operators
+The `Red Hat OpenShift Pipelines` and `Red Hat OpenShift GitOps` operators can be installed from the solution 
+derived from the [Janus IDP Demo](https://github.com/redhat-gpte-devopsautomation/janus-idp-bootstrap)
+>This repository contains automation to install the Janus IDP Demo, as well as supporting components
+
+A fork has been created to remove the configuration that excludes Tekton resources from being configured from the 
+ArgoCD applications (see [discussion](https://github.com/argoproj/argo-cd/discussions/8674#discussioncomment-2318554)).
+
+First, install the `Red Hat OpenShift Pipelines` operator:
+```console
+git clone https://github.com/parodos-dev/janus-idp-bootstrap.git
+cd charts/pipelines-operator
+helm upgrade --install orchestrator-pipelines . -f values.yaml -n orchestrator-gitops --create-namespace
+```
+
+Finally install and configure the `Red Hat OpenShift GitOps` operator:
+```console
+git clone https://github.com/parodos-dev/janus-idp-bootstrap.git
+cd charts/gitops-operator
+helm upgrade --install orchestrator-gitops . -f values.yaml -n orchestrator-gitops --create-namespace --set namespaces={orchestrator-gitops}
+```
+
+## Installing docker credentials
+To allow the Tekton resources to push to the registry, we need an account capable to push the image to the registry:
+
+* Create or edit a [Robot account](https://quay.io/organization/orchestrator?tab=robots) and grant it `Write` permissions to the newly created repository
+* Download `the Docker configuration` file for the robot account and move it under the root folder of this repository (we assume the file name is `orchestrator-orchestror-ci-auth.json`)
+* Run the following to create the `docker-credentials` secret:
+```console
+oc create secret -n orchestrator-gitops generic docker-credentials --from-file=config.json=orchestrator-orchestror-ci-auth.json
+```
+
+## Define the SSH credentials
+The pipeline uses SSH to push the deployment configuration to the `gitops` repository.
+
+Follow these steps to properly configure the credentials in the namespace:
+
+* Generate default SSH keys under the `ssh` folder
+```console
+mkdir -p ssh
+ssh-keygen -t rsa -b 4096 -f ssh/id_rsa -N "" -C git@github.com -q
+```
+* Add the SSH key to your GitHub account using the gh CLI or using the [SSH keys](https://github.com/settings/keys) setting:
+```console
+gh ssh-key add ssh/id_rsa.pub --title "Tekton pipeline"
+```
+* Create a `known_hosts` file by scanning the
+```console
+ssh-keyscan github.com > ssh/known_hosts
+```
+* Create the default `config` file:
+```console
+echo "Host github.com
+  HostName github.com
+  IdentityFile ~/.ssh/id_rsa" > ssh/config
+```
+* Create the secret used by the Pipeline to store the SSH credentials:
+```console
+oc create secret -n orchestrator-gitops generic git-ssh-credentials \
+  --from-file=ssh/id_rsa \
+  --from-file=ssh/config \
+  --from-file=ssh/known_hosts
+```
+Note: if you change the SSH key type from the default value `rsa`, you need to update the `config` file accordingly

--- a/README.md
+++ b/README.md
@@ -26,14 +26,8 @@ This chart will deploy the following on the target OpenShift cluster:
 
 Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL 8 images which are not supported on the ARM64 architecture. Consequently, deployment of this helm chart on an [OpenShift Local](https://www.redhat.com/sysadmin/install-openshift-local) cluster on Macbook laptops with M1/M2 chips is not supported.
 
-### Tekton resources
-The Tekton pipeline requires to configure credentials to access the Quay.io repository and to push on the GitHub repos.
-
-Follow this section to install the required [Prerequisites](https://github.com/parodos-dev/workflows-tekton-pipeline?tab=readme-ov-file#prerequisites).
-
-The next step is to create the [docker credentials](https://github.com/parodos-dev/workflows-tekton-pipeline?tab=readme-ov-file#installing-docker-credentials)
-to push the image artifacts on Quay and [Define the SSH credentials](https://github.com/parodos-dev/workflows-tekton-pipeline?tab=readme-ov-file#define-the-ssh-credentials)
-to push the deployment configuration to the source repository.
+### GitOps environment
+See the dedicated [document](./GitOps.md)
 
 ### Deploying PostgreSQL reference implementation
 Follow these steps to deploy a sample PostgreSQL instance in the `sonataflow-infra` namespace, with minimal requirements to deploy the Orchestrator.

--- a/charts/orchestrator/templates/NOTES.txt
+++ b/charts/orchestrator/templates/NOTES.txt
@@ -59,8 +59,8 @@ SonataFlow Operator          {{ $sonataFlowOperatorInstalled }}        {{ .Value
 SonataFlowPlatform           {{ $sonataFlowPlatformInstalled }}        {{ .Values.orchestrator.namespace }}
 Data Index Service           {{ $sonataFlowPlatformInstalled }}        {{ .Values.orchestrator.namespace }}
 Job Service                  {{ $sonataFlowPlatformInstalled }}        {{ .Values.orchestrator.namespace }}
-Tekton pipeline              {{ $tektonPipelineInstalled }}        {{ .Values.orchestrator.namespace }}
-Tekton task                  {{ $tektonTaskInstalled }}        {{ .Values.orchestrator.namespace }}
+Tekton pipeline              {{ $tektonPipelineInstalled }}        {{ .Values.argocd.namespace }}
+Tekton task                  {{ $tektonTaskInstalled }}        {{ .Values.argocd.namespace }}
 ArgoCD project               {{ $argocdInstalled }}        {{ .Values.argocd.namespace }}
 {{/* Empty line */}}
 ====================================================================

--- a/charts/orchestrator/templates/argocd-project.yaml
+++ b/charts/orchestrator/templates/argocd-project.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: orchestrator
+  name: orchestrator-gitops
   namespace: {{ .Values.argocd.namespace }}
 spec:
   destinations:

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -39,6 +39,11 @@ stringData:
   K8S_CLUSTER_URL: {{ .Values.rhdhOperator.k8s.clusterUrl }}
   K8S_CLUSTER_TOKEN: {{ .Values.rhdhOperator.k8s.clusterToken }}
   {{- end }}
+{{- if .Values.argocd.enabled }}
+  ARGOCD_URL: {{ .Values.argocd.url }}
+  ARGOCD_USERNAME: {{ .Values.argocd.username }}
+  ARGOCD_PASSWORD: {{ .Values.argocd.password }}
+{{- end }}
   {{- if ne .Values.rhdhOperator.github.token "" }}
   GITHUB_TOKEN: {{ .Values.rhdhOperator.github.token }}
   {{- end }}

--- a/charts/orchestrator/templates/tekton-pipeline.yaml
+++ b/charts/orchestrator/templates/tekton-pipeline.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: workflow-deployment
-  namespace: {{ .Values.orchestrator.namespace }}
+  namespace: {{ .Values.argocd.namespace }}
 spec:
   description: |
     This pipeline clones a git repo, builds a Docker image with Kaniko and
@@ -12,7 +12,7 @@ spec:
     - name: gitUrl
       description: The SSH URL of the repository to clone
       type: string
-    - name: gitConfigUrl
+    - name: gitOpsUrl
       description: The SSH URL of the config repository for pushing the changes
       type: string
     - name: workflowId
@@ -24,7 +24,7 @@ spec:
       default: "true"
   workspaces:
     - name: workflow-source
-    - name: workflow-config
+    - name: workflow-gitops
     - name: ssh-creds
     - name: docker-credentials
   tasks:
@@ -49,12 +49,12 @@ spec:
             ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
             git clone $(params.gitUrl) workflow
             cd workflow
-    - name: fetch-workflow-config
+    - name: fetch-workflow-gitops
       taskRef:
         name: git-cli
       workspaces:
         - name: source
-          workspace: workflow-config
+          workspace: workflow-gitops
         - name: ssh-directory
           workspace: ssh-creds
       params:
@@ -68,7 +68,7 @@ spec:
           value: |
             eval "$(ssh-agent -s)"
             ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
-            git clone $(params.gitConfigUrl) workflow-config
+            git clone $(params.gitOpsUrl) workflow-gitops
     - name: flatten-workflow
       runAfter: ["fetch-workflow"]
       taskRef:
@@ -91,15 +91,15 @@ spec:
       params:
         - name: workflowId
           value: $(params.workflowId)
-    - name: build-config
-      runAfter: ["build-manifests", "fetch-workflow-config"]
+    - name: build-gitops
+      runAfter: ["build-manifests", "fetch-workflow-gitops"]
       taskRef:
-        name: build-config
+        name: build-gitops
       workspaces:
         - name: workflow-source
           workspace: workflow-source
-        - name: workflow-config
-          workspace: workflow-config
+        - name: workflow-gitops
+          workspace: workflow-gitops
       params:
         - name: workflowId
           value: $(params.workflowId)
@@ -124,13 +124,13 @@ spec:
           value: flat/$(params.workflowId)
         - name: BUILD_EXTRA_ARGS
           value: --ulimit nofile=4096:4096             
-    - name: push-workflow-config
-      runAfter: ["build-config", "build-and-push-image"]
+    - name: push-workflow-gitops
+      runAfter: ["build-gitops", "build-and-push-image"]
       taskRef:
         name: git-cli
       workspaces:
         - name: source
-          workspace: workflow-config
+          workspace: workflow-gitops
         - name: ssh-directory
           workspace: ssh-creds
       params:
@@ -147,7 +147,7 @@ spec:
             eval "$(ssh-agent -s)"
             ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
 
-            cd workflow-config
+            cd workflow-gitops
             git add .
             git diff
             # TODO: create PR

--- a/charts/orchestrator/templates/tekton-tasks.yaml
+++ b/charts/orchestrator/templates/tekton-tasks.yaml
@@ -4,7 +4,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-cli
-  namespace: {{ .Values.orchestrator.namespace }}
+  namespace: {{ .Values.argocd.namespace }}
   labels:
     app.kubernetes.io/version: "0.4"
   annotations:
@@ -158,7 +158,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: flattener
-  namespace: {{ .Values.orchestrator.namespace }}
+  namespace: {{ .Values.argocd.namespace }}
 spec:
   workspaces:
     - name: workflow-source
@@ -194,7 +194,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: build-manifests
-  namespace: {{ .Values.orchestrator.namespace }}
+  namespace: {{ .Values.argocd.namespace }}
 spec:
   workspaces:
     - name: workflow-source
@@ -214,12 +214,12 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: build-config
-  namespace: {{ .Values.orchestrator.namespace }}
+  name: build-gitops
+  namespace: {{ .Values.argocd.namespace }}
 spec:
   workspaces:
     - name: workflow-source
-    - name: workflow-config
+    - name: workflow-gitops
   params:
     - name: workflowId
       description: The workflow ID from the repository
@@ -227,11 +227,12 @@ spec:
     - name: imageTag
       type: string
   steps:
-    - name: build-config
+    - name: build-gitops
       image: registry.access.redhat.com/ubi9-minimal
-      workingDir: $(workspaces.workflow-config.path)/workflow-config
+      workingDir: $(workspaces.workflow-gitops.path)/workflow-gitops
       script: |
         cp $(workspaces.workflow-source.path)/flat/$(params.workflowId)/manifests/* kustomize/base
         microdnf install -y findutils && microdnf clean all
+        cd kustomize
         ./updater.sh $(params.workflowId) $(params.imageTag)
 {{- end }}

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -54,8 +54,8 @@ tekton:
   enabled: false # whether to create the Tekton pipeline resources
 
 argocd:
-  enabled: false # whether to install the ArgoCD plugin and create the AppProject
+  enabled: false # whether to install the ArgoCD plugin and create the orchestrator AppProject
   url: ""
-  namespace: argocd
+  namespace: orchestrator-gitops
   username: admin
   password: ""


### PR DESCRIPTION
- Renamed gitops namespace to `orchestrator-gitops`
  - Tekton resources are installed in the same namespace
- Restored `ARGOCD` env variables removed by mistake in another commit
- Added docs to initialize the GitOps environment 