### PR TITLE
Update kn workflow tekton-tasks.yaml

### DIFF
--- a/charts/orchestrator/templates/tekton-tasks.yaml
+++ b/charts/orchestrator/templates/tekton-tasks.yaml
@@ -207,9 +207,9 @@ spec:
       image: registry.access.redhat.com/ubi9-minimal
       workingDir: $(workspaces.workflow-source.path)/flat/$(params.workflowId)
       script: |
-        curl -L https://github.com/rgolangh/kie-tools/releases/download/0.0.2/kn-workflow-linux-amd64 -o kn-workflow
-        chmod +x kn-workflow
-        ./kn-workflow gen-manifest --namespace ""
+        KN_CLI_URL="https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz"
+        curl -L "$KN_CLI_URL" | tar -xz && chmod +x kn-linux-amd64 && mv kn-linux-amd64 kn
+        ./kn workflow gen-manifest --namespace ""
 ---
 apiVersion: tekton.dev/v1
 kind: Task


### PR DESCRIPTION
With the release of kn cli, we can use it instead of private build.

Fixes https://github.com/parodos-dev/orchestrator-helm-chart/issues/121