### PR TITLE
Fix tekton pipeline missing mvn when building image

### DIFF
--- a/charts/orchestrator/templates/tekton-pipeline.yaml
+++ b/charts/orchestrator/templates/tekton-pipeline.yaml
@@ -125,7 +125,7 @@ spec:
         - name: BUILD_EXTRA_ARGS
           value: --ulimit nofile=4096:4096       
         - name: BUILD_ARGS
-          value: --build-arg QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-persistence-jdbc:9.99.0.redhat-00007,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final      
+          value: --build-arg MAVEN_ARGS_APPEND=-Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false --build-arg QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-persistence-jdbc:9.99.0.redhat-00007,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final      
     - name: push-workflow-gitops
       runAfter: ["build-gitops", "build-and-push-image"]
       taskRef:


### PR DESCRIPTION
Fix tekton pipeline missing mvn when building image

Similar to https://github.com/parodos-dev/serverless-workflows/pull/171