### PR TITLE
Remove devmode option from the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,20 +62,12 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
     source .env
     ```
 ### ...without GitOps
-1. Install the orchestrator chart using one of the following options:
-   * **Option 1: Install the chart with SonataFlow services in ephemeral mode for evaluation purposes**
+1. Install the orchestrator chart using the following steps:
+    1. Deploy PostgreSQL reference implementation following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
+    2.  Install the orchestrator Helm chart:
       ```console
-      helm install orchestrator orchestrator --set orchestrator.devmode=true \
-          --set rhdhOperator.github.token=$GITHUB_TOKEN \
-          --set rhdhOperator.k8s.clusterToken=$K8S_CLUSTER_TOKEN \
-          --set rhdhOperator.k8s.clusterUrl=$K8S_CLUSTER_URL
+      helm install orchestrator orchestrator --set rhdhOperator.github.token=$GITHUB_TOKEN
       ```
-   * **Option 2: Deploy with persistence**
-      1. Deploy PostgreSQL reference implementation following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
-      2.  Install the orchestrator Helm chart:
-        ```console
-        helm install orchestrator orchestrator --set rhdhOperator.github.token=$GITHUB_TOKEN 
-        ```
 2. Run the commands prompted at the end of the previous step to wait until the services are ready.
 
 
@@ -84,15 +76,6 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
 The Orchestrator installs RHDH and imports software templates designed for bootstrapping workflow development. These templates are crafted to ease the development lifecycle, including a Tekton pipeline to build workflow images and generate the workflow images. Furthermore, ArgoCD is utilized to monitor any changes made to the workflow repository and to automatically trigger the Tekton pipelines as needed. This installation process ensures that all necessary Tekton and ArgoCD resources are provisioned within the same cluster.
 
 1. Install the orchestrator chart using one of the following options:
-   * **Option 1: Install the chart with SonataFlow services in ephemeral mode for evaluation purposes**
-      ```console
-      helm install orchestrator orchestrator --set orchestrator.devmode=true \
-          --set rhdhOperator.github.token=$GITHUB_TOKEN \
-          --set rhdhOperator.k8s.clusterToken=$K8S_CLUSTER_TOKEN --set rhdhOperator.k8s.clusterUrl=$K8S_CLUSTER_URL \
-          --set argocd.namespace=$ARGOCD_NAMESPACE --set argocd.url=$ARGOCD_URL --set argocd.username=$ARGOCD_USERNAME \
-          --set argocd.password=$ARGOCD_PASSWORD --set argocd.enabled=true --set tekton.enabled=true
-      ```
-   * **Option 2: Deploy with persistence**
       1. Deploy PostgreSQL reference implementation following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
       2. Install the orchestrator Helm chart:
         ```console

--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -38,7 +38,6 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `postgres.authSecret.userKey` | name of key in existing secret to use for PostgreSQL credentials. | `"postgres-username"` |
 | `postgres.authSecret.passwordKey` | name of key in existing secret to use for PostgreSQL credentials. | `"postgres-password"` |
 | `postgres.database` | existing database instance used by data index and job service | `"sonataflow"` |
-| `orchestrator.devmode` | devmode runs sonataflow services in ephemeral mode (for a non-production use) | `false` |
 | `orchestrator.namespace` | namespace where the data index, job service and workflows are deployed | `"sonataflow-infra"` |
 | `orchestrator.sonataPlatform.resources.requests.memory` |  | `"64Mi"` |
 | `orchestrator.sonataPlatform.resources.requests.cpu` |  | `"250m"` |

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -52,7 +52,7 @@
 
 
 {{- define "install-tekton-task" -}}
-  {{- if and (or .Values.orchestrator.devmode .Values.tekton.enabled) (ne .Values.rhdhOperator.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Task") }}
+  {{- if and (.Values.tekton.enabled) (ne .Values.rhdhOperator.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Task") }}
         {{- "true" -}}
     {{- else }}
         {{- "false" -}}
@@ -60,7 +60,7 @@
 {{- end -}}
 
 {{- define "install-tekton-pipeline" -}}
-  {{- if and (or .Values.orchestrator.devmode .Values.tekton.enabled) (ne .Values.rhdhOperator.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Pipeline") }}
+  {{- if and (.Values.tekton.enabled) (ne .Values.rhdhOperator.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Pipeline") }}
         {{- "true" -}}
     {{- else }}
         {{- "false" -}}
@@ -68,7 +68,7 @@
 {{- end -}}
 
 {{- define "install-argocd-project" -}}
-    {{- if and (or .Values.orchestrator.devmode .Values.argocd.enabled) (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/AppProject") }}
+    {{- if and (.Values.argocd.enabled) (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/AppProject") }}
         {{- "true" -}}
     {{- else }}
         {{- "false" -}}

--- a/charts/orchestrator/templates/sonataflows.yaml
+++ b/charts/orchestrator/templates/sonataflows.yaml
@@ -1,15 +1,3 @@
-{{- define "persistence" }}
-      persistence:
-        postgresql:
-          secretRef:
-            name: {{ .Values.postgres.authSecret.name }}
-            userKey: {{ .Values.postgres.authSecret.userKey }}
-            passwordKey: {{ .Values.postgres.authSecret.passwordKey }}
-          serviceRef:
-            name: {{ .Values.postgres.serviceName }}
-            namespace: {{ .Values.postgres.serviceNamespace }}
-{{- end }}
-
 {{- if .Values.sonataFlowOperator.enabled }}
 ---
 apiVersion: sonataflow.org/v1alpha08
@@ -26,17 +14,6 @@ spec:
     namespace: {{ .Values.orchestrator.namespace }}
 {{ include "wait-for-crd-available" (dict "releaseName" .Release.Name "releaseNamespace" .Release.Namespace "apiGroup" "sonataflow.org" "kind" "sonataflowclusterplatforms") }}
 {{ include "delete-cr-on-uninstall" (dict "releaseName" .Release.Name "releaseNamespace" .Release.Namespace "apiGroup" "sonataflow.org" "kind" "sonataflowclusterplatforms" "resourceName" "cluster-platform") }}
-  {{- if .Values.orchestrator.devmode }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.orchestrator.namespace }}
-  labels:
-    {{- if .Values.argocd.enabled }}
-    argocd.argoproj.io/managed-by: {{ .Values.argocd.namespace }}
-    {{- end }}
-  {{- end }}
 ---
 apiVersion: sonataflow.org/v1alpha08
 kind: SonataFlowPlatform
@@ -60,14 +37,26 @@ spec:
   services:
     dataIndex:
       enabled: true
-  {{- if not .Values.orchestrator.devmode }}
-    {{- include "persistence" . }}
-  {{- end }}
+      persistence:
+        postgresql:
+          secretRef:
+            name: {{ .Values.postgres.authSecret.name }}
+            userKey: {{ .Values.postgres.authSecret.userKey }}
+            passwordKey: {{ .Values.postgres.authSecret.passwordKey }}
+          serviceRef:
+            name: {{ .Values.postgres.serviceName }}
+            namespace: {{ .Values.postgres.serviceNamespace }}
     jobService:
       enabled: true
-  {{- if not .Values.orchestrator.devmode }}      
-    {{- include "persistence" . }}
-  {{- end }}
+      persistence:
+        postgresql:
+          secretRef:
+            name: {{ .Values.postgres.authSecret.name }}
+            userKey: {{ .Values.postgres.authSecret.userKey }}
+            passwordKey: {{ .Values.postgres.authSecret.passwordKey }}
+          serviceRef:
+            name: {{ .Values.postgres.serviceName }}
+            namespace: {{ .Values.postgres.serviceNamespace }}
 {{ include "wait-for-crd-available" (dict "releaseName" .Release.Name "releaseNamespace" .Release.Namespace "apiGroup" "sonataflow.org" "kind" "sonataflowplatforms") }}
 {{ include "delete-cr-on-uninstall" (dict "releaseName" .Release.Name "releaseNamespace" .Release.Namespace "apiGroup" "sonataflow.org" "kind" "sonataflowplatforms" "targetNamespace" .Values.orchestrator.namespace "resourceName" "sonataflow-platform") }}
 {{- end }}

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -427,19 +427,10 @@
             "default": {},
             "title": "The orchestrator Schema",
             "required": [
-                "devmode",
                 "namespace",
                 "sonataPlatform"
             ],
             "properties": {
-                "devmode": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "The devmode Schema",
-                    "examples": [
-                        false
-                    ]
-                },
                 "namespace": {
                     "type": "string",
                     "default": "",
@@ -555,7 +546,6 @@
                 }
             },
             "examples": [{
-                "devmode": false,
                 "namespace": "sonataflow-infra",
                 "sonataPlatform": {
                     "resources": {
@@ -625,7 +615,7 @@
                     "default": "",
                     "title": "The namespace Schema",
                     "examples": [
-                        "argocd"
+                        "orchestrator-gitops"
                     ]
                 },
                 "username": {
@@ -648,7 +638,7 @@
             "examples": [{
                 "enabled": false,
                 "url": "",
-                "namespace": "argocd",
+                "namespace": "orchestrator-gitops",
                 "username": "admin",
                 "password": ""
             }]
@@ -702,7 +692,6 @@
             "database": "sonataflow"
         },
         "orchestrator": {
-            "devmode": false,
             "namespace": "sonataflow-infra",
             "sonataPlatform": {
                 "resources": {
@@ -723,7 +712,7 @@
         "argocd": {
             "enabled": false,
             "url": "",
-            "namespace": "argocd",
+            "namespace": "orchestrator-gitops",
             "username": "admin",
             "password": ""
         }

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -39,7 +39,6 @@ postgres:
   database: sonataflow # existing database instance used by data index and job service
 
 orchestrator:
-  devmode: false # devmode runs sonataflow services in ephemeral mode (for a non-production use)
   namespace: sonataflow-infra # namespace where the data index, job service and workflows are deployed
   sonataPlatform:
     resources:


### PR DESCRIPTION
The chart is designed to execute workflows reliably, which requires persistence enabled. For that reason, devmode will no longer be needed.