### PR TITLE
orchestrator-k8s: load locations from a local fs

### DIFF
--- a/charts/orchestrator-k8s/Chart.yaml
+++ b/charts/orchestrator-k8s/Chart.yaml
@@ -3,7 +3,7 @@ name: orchestrator-k8s
 description: |
   Helm chart to deploy the Orchestrator solution suite on Kubernetes, including Janus IDP backstage, SonataFlow Operator, Knative Eventing and Knative Serving.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.0.1"
 
 dependencies:

--- a/charts/orchestrator-k8s/locations/basic-workflow-template.yaml
+++ b/charts/orchestrator-k8s/locations/basic-workflow-template.yaml
@@ -1,0 +1,318 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: basic-workflow-bootstrap
+  title: Basic workflow bootstrap project
+  description: Bootstrap project for basic serverless workflows
+  tags:
+    - orchestrator
+    - built-in
+  links:
+    - url: https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html
+      title: About OpenShift Serverless Logic
+      icon: techdocs
+    - url: https://kiegroup.github.io/kogito-docs/serverlessworkflow/latest/index.html
+      title: SonataFlow Guides
+      icon: techdocs
+spec:
+  owner: janus-orchestrator
+  type: basic-workflow-bootstrap
+
+  parameters:
+    - title: Provide information about the workflow software project
+      description: Configure the github repository where the Maven software project is located 
+      required:
+        - orgName
+        - repoName
+        - workflowId
+        - workflowType
+        - owner
+        - system
+      properties:
+        orgName:
+          title: Organization Name
+          type: string
+          ui:autofocus: true
+          description: Github Organization Name
+        repoName:
+          title: Repository Name
+          type: string
+          description: Github repository name
+          default: onboarding
+        description:
+          title: Description
+          type: string
+          description: Description added to the README file
+          default: A workflow for onboarding applications to OCP cluster
+        workflowId:
+          title: Workflow ID
+          type: string
+          pattern: '^([a-zA-Z][a-zA-Z0-9]*)([-.]?[a-zA-Z0-9]+)*$'
+          description: Unique identifier of the workflow in SonataFlow
+          default: onboarding
+        workflowType:
+          title: Workflow Type
+          type: string
+          description: Metadata added to the workflow to distinguish assessment and infrastructure
+          enum:
+            - assessment
+            - infrastructure
+          default: infrastructure
+        owner:
+          title: Owner
+          type: string
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind:
+                - Group
+                - User
+          default: user:guest
+        system:
+          title: System
+          type: string
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind:
+                - System
+    - title: Provide information about the Build environment
+      required:
+        - CI
+      properties:
+        CI:
+          title: Select a CI/CD method
+          type: string
+          description: This action will create a CI pipeline for your application based on chosen method
+          default: tekton_argocd
+          enum:
+            - none
+            - tekton_argocd
+          enumNames:
+            - None
+            - Tekton with ArgoCD
+      # See: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/3019e781b988e0548eb987eed3e522854ed8c52f/templates/github/quarkus-backend/template.yaml#L101
+      dependencies:
+        CI:
+          oneOf:
+            - properties:
+                CI:
+                  const: none
+            - properties:
+                CI:
+                  const: tekton_argocd
+                namespace:
+                  title: Workflow Namespace
+                  type: string
+                  default: sonataflow-infra
+                  description: Deployment namespace for workflow applications
+                argocdNamespace:
+                  title: GitOps Namespace
+                  type: string
+                  default: orchestrator-gitops
+                  description: Deployment namespace for ArgoCD and Tekton resources
+                sshPrivateKey:
+                  title: SSH private key
+                  type: string
+                  description: Private SSH key associated with the GitHub account - Use Base64 encoding
+                  ui:widget: password
+                  ui:options: 'rows: 10'
+                persistenceEnabled:
+                  title: Enable Persistance
+                  type: boolean
+                  description: Indicates whether the workflow shall have persistence enabled.
+                  default: false
+              required:
+                - namespace
+                - argocdNamespace
+                - sshPrivateKey
+                - persistenceEnabled
+              dependencies:
+                persistenceEnabled:
+                  oneOf:
+                      - properties:
+                          persistenceEnabled:
+                            const: false
+                      - properties:
+                          persistenceEnabled:
+                            const: true
+                          persistencePSQLSecretName:
+                            title: PostgreSQL Secret Name
+                            type: string
+                            default: sonataflow-psql-postgresql
+                            description: Name of the secret in which the PostgreSQL secrets are stored. Shall be in the same namespace as the workflow.
+                          persistencePSQLUserKey:
+                            title: PostgreSQL User key from secret
+                            type: string
+                            description: The key name in which the PostgreSQL user is stored.
+                            default: postgres-username
+                          persistencePSQLPasswordKey:
+                            title: PostgreSQL Password key from secret
+                            type: string
+                            description: The key name in which the PostgreSQL password is stored.
+                            default: postgres-password
+                          persistencePSQLServiceName:
+                            title: PostgreSQL K8s Service Name
+                            type: string
+                            default: sonataflow-psql-postgresql
+                            description: Name of the service running the PostgreSQL instance.
+                          persistencePSQLServicePort:
+                            title: PostgreSQL Port
+                            type: integer
+                            default: 5432
+                            description: Port on which the PostgreSQL instance is running.
+                          persistencePSQLDatabaseName:
+                            title: PostgreSQL Database Name
+                            type: string
+                            description: Name of the database to use for persistence.
+                            default: sonataflow
+                        required:
+                          - persistencePSQLSecretName
+                          - persistencePSQLUserKey
+                          - persistencePSQLPasswordKey
+                          - persistencePSQLServiceName
+                          - persistencePSQLServicePort
+                          - persistencePSQLDatabaseName         
+  steps:
+    - id: workflowCodeTemplate
+      name: Generating the Workflow Source Code and Catalog Info Component
+      action: fetch:template
+      input:
+        # "Relative path is not allowed to refer to a directory outside its parent"
+        url: ./skeleton
+        values:
+          namespace: ${{ parameters.namespace }}
+          argocdNamespace: ${{ parameters.argocdNamespace }}
+          orgName: ${{ parameters.orgName }}
+          repoName: ${{ parameters.repoName }}
+          owner: ${{ parameters.owner }}
+          system: ${{ parameters.system }}
+          description: ${{ parameters.description }}
+          groupId: io.janus.workflow
+          artifactId: ${{ parameters.workflowId }}
+          version: 1.0.0-SNAPSHOT
+          workflowId: ${{ parameters.workflowId }}
+          workflowType: ${{ parameters.workflowType }}
+          sourceControl: github.com
+          applicationType: workflow-project
+          lifecycle: development
+          persistenceEnabled: ${{ parameters.persistenceEnabled }}
+        targetPath: workflow
+    - id: renameFiles
+      action: fs:rename
+      name: Rename files
+      input:
+        files:
+          - from: workflow/src/main/resources/${{ parameters.workflowType }}-template.sw.yaml
+            to: workflow/src/main/resources/${{ parameters.workflowId }}.sw.yaml
+            overwrite: false
+    - id: deleteFiles
+      action: fs:delete
+      name: Delete files
+      input:
+        files:
+          - workflow/src/main/resources/assessment-template.sw.yaml
+          - workflow/src/main/resources/infrastructure-template.sw.yaml
+    - id: buildCodeTemplate
+      name: Generating the Build Code for the Workflow
+      action: fetch:template
+      if: ${{ parameters.CI == 'tekton_argocd' }}
+      input:
+        url: ../build
+        copyWithoutTemplating:
+          - .github/workflows/update_pipelinerun.yaml
+        values:
+          namespace: ${{ parameters.namespace }}
+          argocdNamespace: ${{ parameters.argocdNamespace }}
+          orgName: ${{ parameters.orgName }}
+          workflowId: ${{ parameters.workflowId }}
+          gitUrl: git@github.com:${{ parameters.orgName }}/${{ parameters.repoName }}.git
+          gitOpsUrl: git@github.com:${{ parameters.orgName }}/${{ parameters.repoName }}-gitops.git
+        targetPath: workflow
+    - id: publishWorkflow
+      name: Publishing to the Workflow Repository
+      action: publish:github  
+      input:
+        allowedHosts: ['github.com']
+        description: ${{ parameters.description }}
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}
+        defaultBranch: main
+        sourcePath: workflow
+    - id: register
+      name: Registering the Catalog Info Component
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps.publishWorkflow.output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+    - id: gitopsCodeTemplate
+      name: Generating the GitOps Component and Catalog Info Component
+      action: fetch:template
+      if: ${{ parameters.CI == 'tekton_argocd' }}
+      input:
+        url: ../gitops
+        values:
+          workflowId: ${{ parameters.workflowId }}
+          namespace: ${{ parameters.namespace }}
+          argocdNamespace: ${{ parameters.argocdNamespace }}
+          orgName: ${{ parameters.orgName }}
+          repoName: ${{ parameters.repoName }}-gitops
+          owner: ${{ parameters.owner }}
+          system: ${{ parameters.system }}
+          applicationType: workflow-project
+          description: ${{ parameters.description }}
+          sourceControl: github.com
+          lifecycle: development
+          gitUrl: git@github.com:${{ parameters.orgName }}/${{ parameters.repoName }}.git
+          gitOpsUrl: git@github.com:${{ parameters.orgName }}/${{ parameters.repoName }}-gitops.git
+          sshPrivateKey: ${{ parameters.sshPrivateKey }}
+          persistencePSQLSecretName: ${{ parameters.persistencePSQLSecretName }}
+          persistencePSQLUserKey: ${{ parameters.persistencePSQLUserKey }}
+          persistencePSQLPasswordKey: ${{ parameters.persistencePSQLPasswordKey }}
+          persistencePSQLServiceName: ${{ parameters.persistencePSQLServiceName }}
+          persistencePSQLServicePort: ${{ parameters.persistencePSQLServicePort }}
+          persistencePSQLDatabaseName: ${{ parameters.persistencePSQLDatabaseName }}
+          persistencePSQLDatabaseSchema: ${{ parameters.workflowId }}
+          persistenceEnabled: ${{ parameters.persistenceEnabled }}
+        targetPath: gitops
+    - id: renameFilesForPersistence
+      action: fs:rename
+      if: ${{ parameters.persistenceEnabled == true }}
+      name: Rename files for persistence
+      input:
+        files:
+          - from: gitops/kustomize/base/sonataflow-patch-persistence.yaml
+            to: gitops/kustomize/base/sonataflow-patch.yaml
+            overwrite: true
+    - id: cleanFilesForPersistence
+      action: fs:delete
+      if: ${{ parameters.persistenceEnabled == false }}
+      name: Clean persistence files
+      input:
+        files:
+          - gitops/kustomize/base/sonataflow-patch-persistence.yaml
+    - id: publishGitOps
+      name: Publishing to the GitOps Code Repository
+      action: publish:github
+      input:
+        allowedHosts: ['github.com']
+        description: Configuration repository for ${{ parameters.orgName }}/${{ parameters.repoName }}
+        repoUrl: github.com?owner=${{ parameters.orgName }}&repo=${{ parameters.repoName }}-gitops
+        defaultBranch: main
+        sourcePath: gitops
+    - id: registerGitOps
+      name: Registering the GitOps Catalog Info Component
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps.publishGitOps.output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+  output:
+    links:
+      - if: ${{ parameters.CI == 'tekton_argocd' }}
+        title: Bootstrap the GitOps Resources
+        url: https://github.com/${{ parameters.orgName }}/${{ parameters.repoName }}-gitops/tree/main/bootstrap
+      - title: Open the Source Code Repository
+        url: ${{ steps.publishWorkflow.output.remoteUrl }}
+      - title: Open the Catalog Info Component
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}
+

--- a/charts/orchestrator-k8s/locations/users.yaml
+++ b/charts/orchestrator-k8s/locations/users.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: User
+metadata:
+  name: guest
+spec:
+  profile:
+    displayName: Guest User
+  memberOf: []

--- a/charts/orchestrator-k8s/locations/workflow-resources.yaml
+++ b/charts/orchestrator-k8s/locations/workflow-resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: workflow-orchestrator-entities
+  description: A collection of Backstage entities for Workflow orchestrator
+spec:
+  type: url
+  targets:
+    - https://github.com/parodos-dev/workflow-software-templates/tree/main/entities/system.yaml
+    - https://github.com/parodos-dev/workflow-software-templates/tree/main/entities/group.yaml

--- a/charts/orchestrator-k8s/templates/backstage-locations-configmap.yaml
+++ b/charts/orchestrator-k8s/templates/backstage-locations-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+{{ (.Files.Glob "locations/*").AsConfig | indent 2 }}
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: backstage-locations

--- a/charts/orchestrator-k8s/values.yaml
+++ b/charts/orchestrator-k8s/values.yaml
@@ -96,6 +96,42 @@ backstage:
     ingress:
       enabled: true  # Use Kubernetes Ingress instead of OpenShift Route
     backstage:
+      extraVolumes:
+        - name: backstage-locations
+          configMap:
+            name: backstage-locations
+
+        - name: dynamic-plugins-root
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    # -- Size of the volume that will contain the dynamic plugins. It should be large enough to contain all the plugins.
+                    storage: 1Gi
+
+
+        # Volume that will expose the `dynamic-plugins.yaml` file from the `dynamic-plugins` config map.
+        # The `dynamic-plugins` config map is created by the helm chart from the content of the `global.dynamic` field.
+        - name: dynamic-plugins
+          configMap:
+            defaultMode: 420
+            name: dynamic-plugins
+            optional: true
+        # Optional volume that allows exposing the `.npmrc` file (through a `dynamic-plugins-npmrc` secret)
+        # to be used when running `npm pack` during the dynamic plugins installation by the initContainer.
+        - name: dynamic-plugins-npmrc
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: dynamic-plugins-npmrc
+      extraVolumeMounts:
+        - name: dynamic-plugins-root
+          mountPath: /opt/app-root/src/dynamic-plugins-root
+        - name: backstage-locations
+          mountPath: /opt/backstage/locations
       resources:
         limits:
           memory: 2Gi
@@ -144,19 +180,20 @@ backstage:
                   Domain,
                 ]
           locations:
-            - type: url
-              target: https://github.com/parodos-dev/workflow-software-templates/blob/main/entities/workflow-resources.yaml
-            - type: url
-              target: https://github.com/parodos-dev/workflow-software-templates/blob/main/template/template.yaml
-            - type: url
-              target: https://github.com/janus-idp/software-templates/blob/main/showcase-templates.yaml
+            - target: https://github.com/janus-idp/software-templates/blob/main/showcase-templates.yaml
+              type: url
+            - target: /opt/backstage/locations/basic-workflow-template.yaml
+              type: file
+            - target: /opt/backstage/locations/users.yaml
+              type: file
+            - target: /opt/backstage/locations/workflow-resources.yaml
+              type: file
+
           csp:
             frame-src:
               - "https://sandbox.kie.org"
         orchestrator:
           catalog:
             environment: development
-
-          
-
+    
 


### PR DESCRIPTION
Loading backstage locations from URL is limiting when all you need is to be up and running with notifications plugins working and you don't want the extra steps to configure a github token just to be able to pull those in
Instead the chart would install those locatios files in a config map from the `/locations` directory 
The price to pay is that those location files need to manually downloaded and placed in the location dir from time to time.
note: the location file in the values.yaml must match the name in the config map

To use the mount in backstage there's a new `backstage-location` config map and an `backstage.extraVolumes` and `backstage.extraVolumeMounts` config entries in values.yaml

Signed-off-by: Roy Golan <rgolan@redhat.com>
