### PR TITLE
Set specific path to authfile

### DIFF
--- a/charts/orchestrator-k8s/Chart.yaml
+++ b/charts/orchestrator-k8s/Chart.yaml
@@ -3,7 +3,7 @@ name: orchestrator-k8s
 description: |
   Helm chart to deploy the Orchestrator solution suite on Kubernetes, including Janus IDP backstage, SonataFlow Operator, Knative Eventing and Knative Serving.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.0.1"
 
 dependencies:

--- a/charts/orchestrator/templates/tekton-pipeline.yaml
+++ b/charts/orchestrator/templates/tekton-pipeline.yaml
@@ -123,7 +123,7 @@ spec:
         - name: CONTEXT
           value: flat/$(params.workflowId)
         - name: BUILD_EXTRA_ARGS
-          value: '--ulimit nofile=4096:4096 --build-arg WF_RESOURCES="." --build-arg MAVEN_ARGS_APPEND="-Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false" --build-arg QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT,org.kie:kie-addons-quarkus-persistence-jdbc:999-20240317-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final'
+          value: '--authfile=/workspace/dockerconfig/.dockerconfigjson --ulimit nofile=4096:4096 --build-arg WF_RESOURCES="." --build-arg MAVEN_ARGS_APPEND="-Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false" --build-arg QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT,org.kie:kie-addons-quarkus-persistence-jdbc:999-20240317-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final'
     - name: push-workflow-gitops
       runAfter: ["build-gitops", "build-and-push-image"]
       taskRef:


### PR DESCRIPTION
Seems buildah isn't capable of finding the registry auth file in the expected path.

```
DEBU[0000] No credentials matching registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 found in /var/tmp/containers-user-0/containers/containers/auth.json
DEBU[0000] No credentials matching registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 found in /root/.config/containers/auth.json
DEBU[0000] No credentials matching registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 found in /root/.docker/config.json
DEBU[0000] No credentials matching registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 found in /root/.dockercfg
DEBU[0000] No credentials for registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 found

```
By specifying the path, this seems to work:
```
DEBU[0000] Found credentials for registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8 in credential helper containers-auth.json in file /workspace/dockerconfig/.dockerconfigjson
```