### PR TITLE
fixes in setenv script

### DIFF
--- a/hack/setenv.sh
+++ b/hack/setenv.sh
@@ -50,7 +50,7 @@ function exportK8sToken {
   oc adm policy add-cluster-role-to-user cluster-admin -z $sa_name -n $sa_namespace
   echo "Added cluster-admin role to '$sa_name' in '$sa_namespace'."
   token_secret=$(oc get secret -o name -n $sa_namespace | grep ${sa_name}-token)
-  token=$(oc get -n $sa_namespace ${token_secret} -o yaml | yq '.data.token' | sed 's/"//g' | base64 -d)
+  token=$(oc get -n $sa_namespace ${token_secret} -o jsonpath="{.data.token}" | sed 's/"//g' | base64 -d)
   echo "export K8S_CLUSTER_TOKEN=$token" >> .env
 }
 
@@ -116,10 +116,6 @@ function exportArgoCDCreds {
 }
 
 function checkPrerequisite {
-  if ! command -v yq &> /dev/null; then
-    echo "yq is required for this script to run. Exiting."
-    exit 1
-  fi
   if ! command -v oc &> /dev/null; then
     echo "oc is required for this script to run. Exiting."
     exit 1
@@ -165,6 +161,7 @@ else
 fi
 
 checkPrerequisite
+cleanUpEnvFile
 exportWorkflowNamespace
 exportK8sURL
 exportK8sToken


### PR DESCRIPTION
removes dependency on yq
resolves [FLPATH-1220](https://issues.redhat.com/browse/FLPATH-1220): [Documentation hack setenv script] If you run the script twice, the preivous entries are not deleted