### PR TITLE
several README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Orchestrator Helm Chart
+
 Deploy the Orchestrator solution suite using this Helm chart.\
 The chart installs the following components onto the target OpenShift cluster:
+
 - RHDH (Red Hat Developer Hub) Backstage
 - OpenShift Serverless Logic Operator (with Data-Index and Job Service)
 - OpenShift Serverless Operator
@@ -10,9 +12,11 @@ The chart installs the following components onto the target OpenShift cluster:
 - Tekton tasks and build pipeline (optional: disabled by default)
 
 ## Important Note for ARM64 Architecture Users
+
 Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL 8 images which are not supported on the ARM64 architecture. Consequently, deployment of this helm chart on an [OpenShift Local](https://www.redhat.com/sysadmin/install-openshift-local) cluster on MacBook laptops with M1/M2 chips is not supported.
 
 ## Prerequisites
+
 - Logged in to a Red Hat OpenShift Container Platform (version 4.13+) cluster as a cluster administrator.
 - [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html) is installed.
 - [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/docs/getting-started/) has been installed in your cluster.
@@ -28,92 +32,105 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
 ## Installation
 
 1. Get the Helm chart from one of the following options
-    * **Pre-Packaged Helm Chart**\
-      If you choose to install the Helm chart from the Helm repository, you'll be leveraging the pre-packaged version provided by the chart maintainer. This method is convenient and ensures that you're using a stable, tested version of the chart.
-      Add the repository:
-      ```bash
-      helm repo add orchestrator https://parodos-dev.github.io/orchestrator-helm-chart
-      ```
 
-      Expect result:
-      ```
-      "orchestrator" has been added to your repositories
-      ```
+   - **Pre-Packaged Helm Chart**\
+     If you choose to install the Helm chart from the Helm repository, you'll be leveraging the pre-packaged version provided by the chart maintainer. This method is convenient and ensures that you're using a stable, tested version of the chart.
+     Add the repository:
 
-      Verify the repository is shown:
-      ```
-      helm repo list
-      ```
+     ```bash
+     helm repo add orchestrator https://parodos-dev.github.io/orchestrator-helm-chart
+     ```
 
-      Expect result:
-      ```
-      NAME        	URL                                                  
-      orchestrator	https://parodos-dev.github.io/orchestrator-helm-chart
-      ```
-   * **Manual Chart Deployment**\
-      By cloning the repository and navigating to the charts directory, you'll have access to the raw chart files and can customize them to fit your specific requirements.\
-      ```console
-      git clone git@github.com:parodos-dev/orchestrator-helm-chart.git
-      cd orchestrator-helm-chart/charts
-      ```
+     Expect result:
+
+     ```
+     "orchestrator" has been added to your repositories
+     ```
+
+     Verify the repository is shown:
+
+     ```
+     helm repo list
+     ```
+
+     Expect result:
+
+     ```
+     NAME        	URL
+     orchestrator	https://parodos-dev.github.io/orchestrator-helm-chart
+     ```
+
+   - **Manual Chart Deployment**\
+      By cloning the repository and navigating to the charts directory, you'll have access to the raw chart files and can customize them to fit your specific requirements.
+     ```console
+     git clone git@github.com:parodos-dev/orchestrator-helm-chart.git
+     cd orchestrator-helm-chart/charts
+     ```
+
 2. Create a namespace for the Orchestrator solution:
-      ```console
-      oc new-project orchestrator
-      ```
-3. Run the following command to set up environment variables:
+
+   ```console
+   oc new-project orchestrator
+   ```
+
+3. Set GITHUB_TOKEN environment variable
+
+   ```console
+   export GITHUB_TOKEN=<github token>
+   ```
+
+4. Deploy PostgreSQL reference implementation following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
+
+### ...without GitOps
+
+1.  Install the orchestrator Helm chart:
+
+    ```console
+    helm upgrade -i orchestrator orchestrator --set rhdhOperator.github.token=$GITHUB_TOKEN
+    ```
+
+2.  Run the commands prompted at the end of the previous step to wait until the services are ready.
+
+### ... with GitOps
+
+1.  Install `Red Hat OpenShift Pipelines` and `Red Hat OpenShift GitOps` operators following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/gitops/README.md).
+    The Orchestrator installs RHDH and imports software templates designed for bootstrapping workflow development. These templates are crafted to ease the development lifecycle, including a Tekton pipeline to build workflow images and generate workflow K8s custom resources. Furthermore, ArgoCD is utilized to monitor any changes made to the workflow repository and to automatically trigger the Tekton pipelines as needed. This installation process ensures that all necessary Tekton and ArgoCD resources are provisioned within the same cluster.
+
+2.  Run the following command to set up environment variables:
+
     ```console
     ./hack/setenv.sh --use-default
     ```
+
     This script generates a `.env` file that contains all the calculated environment variables.
 
-    >**NOTE:** If you don't want to use the default values, omit the `--use-default` and the script will prompt you for input.   
-    - Provide GH Token (created as described in prerequisite section)
-    > **NOTE:** 
+    > **NOTE:** If you don't want to use the default values, omit the `--use-default` and the script will prompt you for input.
+    >
     > Default values are calculated as follows:
-    >  * `WORKFLOW_NAMESPACE`: Default value is set to `sonataflow-infra`.
-    >  * `K8S_CLUSTER_URL`: The URL of the Kubernetes cluster is obtained dynamically using `oc whoami --show-server`.
-    >  * `K8S_CLUSTER_TOKEN`: The value is obtained dynamically based on the provided namespace and service account.
-    >  * `GITHUB_TOKEN`: This value is prompted from the user during script execution and is not predefined.
-    >  * `ARGOCD_NAMESPACE`: Default value is set to `orchestrator-gitops`.
-    >  * `ARGOCD_URL`: This value is dynamically obtained based on the first ArgoCD instance available.
-    >  * `ARGOCD_USERNAME`: Default value is set to `admin`.
-    >  * `ARGOCD_PASSWORD`: This value is dynamically obtained based on the first ArgoCD instance available.
-    
-4. Source the environment variables by running
+    >
+    > - `WORKFLOW_NAMESPACE`: Default value is set to `sonataflow-infra`.
+    > - `K8S_CLUSTER_URL`: The URL of the Kubernetes cluster is obtained dynamically using `oc whoami --show-server`.
+    > - `K8S_CLUSTER_TOKEN`: The value is obtained dynamically based on the provided namespace and service account.
+    > - `GITHUB_TOKEN`: This value is prompted from the user during script execution and is not predefined.
+    > - `ARGOCD_NAMESPACE`: Default value is set to `orchestrator-gitops`.
+    > - `ARGOCD_URL`: This value is dynamically obtained based on the first ArgoCD instance available.
+    > - `ARGOCD_USERNAME`: Default value is set to `admin`.
+    > - `ARGOCD_PASSWORD`: This value is dynamically obtained based on the first ArgoCD instance available.
+
+3.  Install the orchestrator Helm chart:
+
     ```console
-    source .env
+    helm upgrade -i orchestrator orchestrator --set rhdhOperator.github.token=$GITHUB_TOKEN \
+    --set rhdhOperator.k8s.clusterToken=$K8S_CLUSTER_TOKEN --set rhdhOperator.k8s.clusterUrl=$K8S_CLUSTER_URL \
+    --set argocd.namespace=$ARGOCD_NAMESPACE --set argocd.url=$ARGOCD_URL --set argocd.username=$ARGOCD_USERNAME \
+    --set argocd.password=$ARGOCD_PASSWORD --set argocd.enabled=true --set tekton.enabled=true
     ```
-### ...without GitOps
-1. Install the orchestrator chart using the following steps:
-    1. Deploy PostgreSQL reference implementation following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
-    2.  Install the orchestrator Helm chart:
-      ```console
-      helm install orchestrator orchestrator --set rhdhOperator.github.token=$GITHUB_TOKEN
-      ```
-2. Run the commands prompted at the end of the previous step to wait until the services are ready.
 
-
-### ... with GitOps
-1. Install `Red Hat OpenShift Pipelines` and `Red Hat OpenShift GitOps` operators following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/gitops/README.md).
-The Orchestrator installs RHDH and imports software templates designed for bootstrapping workflow development. These templates are crafted to ease the development lifecycle, including a Tekton pipeline to build workflow images and generate workflow K8s custom resources. Furthermore, ArgoCD is utilized to monitor any changes made to the workflow repository and to automatically trigger the Tekton pipelines as needed. This installation process ensures that all necessary Tekton and ArgoCD resources are provisioned within the same cluster.
-
-1. Install the orchestrator chart using one of the following options:
-    1. Deploy PostgreSQL reference implementation following these [instructions](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
-    2. Run the script to include GitOps variables:
-       ```console
-       ./hack/setenv.sh --use-default
-       ```
-    4. Install the orchestrator Helm chart:
-      ```console
-      helm install orchestrator orchestrator --set rhdhOperator.github.token=$GITHUB_TOKEN \
-        --set rhdhOperator.k8s.clusterToken=$K8S_CLUSTER_TOKEN --set rhdhOperator.k8s.clusterUrl=$K8S_CLUSTER_URL \
-        --set argocd.namespace=$ARGOCD_NAMESPACE --set argocd.url=$ARGOCD_URL --set argocd.username=$ARGOCD_USERNAME \
-        --set argocd.password=$ARGOCD_PASSWORD --set argocd.enabled=true --set tekton.enabled=true
-      ```
-1. Run the commands prompted at the end of the previous step to wait until the services are ready.
+4.  Run the commands prompted at the end of the previous step to wait until the services are ready.
 
     Sample output:
-    ```console
+
+    ````console
     NAME: orchestrator
     LAST DEPLOYED: Fri Mar 29 12:34:59 2024
     NAMESPACE: sonataflow-infra
@@ -127,7 +144,7 @@ The Orchestrator installs RHDH and imports software templates designed for boots
     ====================================================================
     Backstage                    YES        rhdh-operator
     Postgres DB - Backstage      NO         rhdh-operator
-    Red Hat Serverless Operator  YES        openshift-serverless     
+    Red Hat Serverless Operator  YES        openshift-serverless
     KnativeServing               YES        knative-serving
     KnativeEventing              YES        knative-eventing
     SonataFlow Operator          YES        openshift-serverless-logic
@@ -147,6 +164,7 @@ The Orchestrator installs RHDH and imports software templates designed for boots
 
 
     Run the following commands to wait until the services are ready:
+    ```console
       oc wait -n openshift-serverless deploy/knative-openshift --for=condition=Available --timeout=5m
       oc wait -n knative-eventing knativeeventing/knative-eventing --for=condition=Ready --timeout=5m
       oc wait -n knative-serving knativeserving/knative-serving --for=condition=Ready --timeout=5m
@@ -156,13 +174,16 @@ The Orchestrator installs RHDH and imports software templates designed for boots
       oc wait -n sonataflow-infra deploy/sonataflow-platform-jobs-service --for=condition=Available --timeout=5m
       oc wait -n rhdh-operator backstage backstage --for=condition=Deployed=True
       oc wait -n rhdh-operator deploy/backstage-backstage --for=condition=Available --timeout=5m
-    ```
+    ````
+
 During the installation process, Kubernetes jobs are created by the chart to monitor the installation progress and wait for the CRDs to be fully deployed by the operators. In case of any failure at this stage, these jobs remain active, facilitating administrators in retrieving detailed diagnostic information to identify and address the cause of the failure.
 
 > **Note:** that these jobs are automatically deleted after the deployment of the chart is completed.
 
 ### For installing from OpenShift Developer perspective
+
 Create the `HelmChartRepository` from CLI (or from OpenShift UI):
+
 ```shell
 cat << EOF | oc apply -f -
 apiVersion: helm.openshift.io/v1beta1
@@ -174,41 +195,53 @@ spec:
     url: 'https://parodos-dev.github.io/orchestrator-helm-chart'
 EOF
 ```
+
 Follow Helm Chart installation instructions [here](https://docs.openshift.com/container-platform/4.15/applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.html)
 
 ## Additional information
 
 ### Prerequisites
+
 In addition to the [prerequisites](https://github.com/parodos-dev/orchestrator-helm-chart#prerequisites) mentioned earlier, it is possible to manually install the following operator:
+
 - `ArgoCD/OpenShift GitOps` operator
   - Ensure at least one instance of `ArgoCD` exists in the designated namespace (referenced by `ARGOCD_NAMESPACE` environment variable).
   - Validated API is `argoproj.io/v1alpha1/AppProject`
-- `Tekton/OpenShift Pipelines` operator 
+- `Tekton/OpenShift Pipelines` operator
   - Validated APIs are `tekton.dev/v1beta1/Task` and `tekton.dev/v1/Pipeline`
 
 ### GitOps environment
+
 See the dedicated [document](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/GitOps.md)
 
 ### Deploying PostgreSQL reference implementation
+
 See [here](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/postgresql/README.md)
 
 ### ArgoCD and workflow namespace
+
 If you manually created the workflow namespaces (e.g., `$WORKFLOW_NAMESPACE`), run this command to add the required label that allows ArgoCD deploying instances there:
+
 ```console
 oc label ns $WORKFLOW_NAMESPACE argocd.argoproj.io/managed-by=$ARGOCD_NAMESPACE
 ```
 
 ### Workflow installation
+
 Follow [Workflows Installation](https://www.parodos.dev/serverless-workflows-config/)
 
 ## Cleanup
+
 To remove the installation from the cluster, run:
+
 ```console
 helm delete orchestrator
 release "orchestrator" uninstalled
 ```
+
 Note that the CRDs created during the installation process will remain in the cluster.
 To clean the rest of the resources, run:
+
 ```console
 oc get crd -o name | grep -e sonataflow -e rhdh | xargs oc delete
 oc delete namespace orchestrator
@@ -219,5 +252,6 @@ oc delete namespace orchestrator
 ### Timeout or errors during `oc wait` commands
 
 If you encounter errors or timeouts while executing `oc wait` commands, follow these steps to troubleshoot and resolve the issue:
+
 1. **Check Deployment Status**: Review the output of the `oc wait` commands to identify which deployments met the condition and which ones encountered errors or timeouts.
-For example, if you see `error: timed out waiting for the condition on deployments/sonataflow-platform-data-index-service`, investigate further using `oc describe deployment sonataflow-platform-data-index-service -n sonataflow-infra` and `oc logs sonataflow-platform-data-index-service -n sonataflow-infra `
+   For example, if you see `error: timed out waiting for the condition on deployments/sonataflow-platform-data-index-service`, investigate further using `oc describe deployment sonataflow-platform-data-index-service -n sonataflow-infra` and `oc logs sonataflow-platform-data-index-service -n sonataflow-infra `

--- a/gitops/README.md
+++ b/gitops/README.md
@@ -1,13 +1,17 @@
 # Initialize the GitOps environment
-## Install the operators
-The `Red Hat OpenShift Pipelines` and `Red Hat OpenShift GitOps` operators can be installed from the solution 
-derived from the [Janus IDP Demo](https://github.com/redhat-gpte-devopsautomation/janus-idp-bootstrap)
->This repository contains automation to install the Janus IDP Demo, as well as supporting components
 
-A fork has been created to remove the configuration that excludes Tekton resources from being configured from the 
+## Install the operators
+
+The `Red Hat OpenShift Pipelines` and `Red Hat OpenShift GitOps` operators can be installed from the solution
+derived from the [Janus IDP Demo](https://github.com/redhat-gpte-devopsautomation/janus-idp-bootstrap)
+
+> This repository contains automation to install the Janus IDP Demo, as well as supporting components
+
+A fork has been created to remove the configuration that excludes Tekton resources from being configured from the
 ArgoCD applications (see [discussion](https://github.com/argoproj/argo-cd/discussions/8674#discussioncomment-2318554)).
 
 First, install the `Red Hat OpenShift Pipelines` operator:
+
 ```bash
 git clone https://github.com/parodos-dev/janus-idp-bootstrap.git
 cd janus-idp-bootstrap/charts
@@ -15,55 +19,70 @@ helm upgrade --install orchestrator-pipelines pipelines-operator/ -f pipelines-o
 ```
 
 Finally, install and configure the `Red Hat OpenShift GitOps` operator:
+
 ```bash
 helm upgrade --install orchestrator-gitops gitops-operator/ -f gitops-operator/values.yaml -n orchestrator-gitops --create-namespace --set namespaces={orchestrator-gitops}
 ```
 
 ## Installing docker credentials
+
 To allow the Tekton resources to push to the registry, we need an account capable of pushing the image to the registry:
 
-* Create or edit a [Robot account](https://access.redhat.com/documentation/en-us/red_hat_quay/3.3/html/use_red_hat_quay/use-quay-manage-repo) and grant it `Write` permissions to the newly created repository
-* Download the `Docker configuration` file for the robot account and move it under the root folder of this repository (we assume the file name is `orchestrator-auth.json`)
-* When using a [builder image](https://github.com/parodos-dev/serverless-workflows/blob/main/pipeline/workflow-builder.Dockerfile) for serverless workflows from [registry.redhat.io](registry.redhat.io), it is also required to add also the credential to pull from it as described [here](https://access.redhat.com/terms-based-registry/token/orchestrator/docker-config). Merge the credential into a single file `orchestrator-auth.json` with the credentials from the previous step.
-* Run the following to create the `docker-credentials` secret:
+- Create or edit a [Robot account](https://access.redhat.com/documentation/en-us/red_hat_quay/3.3/html/use_red_hat_quay/use-quay-manage-repo) and grant it `Write` permissions to the newly created repository
+- Download the `Docker configuration` (we assume the file name is `orchestrator-auth.json`), place it in a directory of the choice and navigate to that directory.
+- When using a [builder image](https://github.com/parodos-dev/serverless-workflows/blob/main/pipeline/workflow-builder.Dockerfile) for serverless workflows from [registry.redhat.io](registry.redhat.io), it is also required to add also the credential to pull from it as described [here](https://access.redhat.com/terms-based-registry/token/orchestrator/docker-config). Merge the credential into a single file `orchestrator-auth.json` with the credentials from the previous step.
+- Run the following to create the `docker-credentials` secret:
+
 ```console
 oc create secret -n orchestrator-gitops generic docker-credentials --from-file=config.json=orchestrator-auth.json
 ```
 
 ## Define the SSH credentials
+
 The pipeline uses SSH to push the deployment configuration to the `gitops` repository containing the `kustomize` deployment configuration.
 
 Follow these steps to properly configure the credentials in the namespace:
 
-* Generate default SSH keys under the `ssh` folder
+- Generate default SSH keys under the `ssh` folder
+
 ```console
 mkdir -p ssh
 ssh-keygen -t rsa -b 4096 -f ssh/id_rsa -N "" -C git@github.com -q
 ```
-* Add the SSH key to your GitHub account using the gh CLI or using the [SSH keys](https://github.com/settings/keys) setting:
+
+- Add the SSH key to your GitHub account using the gh CLI or using the [SSH keys](https://github.com/settings/keys) setting:
+
 ```console
 gh ssh-key add ssh/id_rsa.pub --title "Tekton pipeline"
 ```
-* Create a `known_hosts` file by scanning the GitHub's SSH public key:
+
+- Create a `known_hosts` file by scanning the GitHub's SSH public key:
+
 ```console
 ssh-keyscan github.com > ssh/known_hosts
 ```
-* Create the default `config` file:
+
+- Create the default `config` file:
+
 ```console
 echo "Host github.com
   HostName github.com
   IdentityFile ~/.ssh/id_rsa" > ssh/config
 ```
-* Create the secret that the Pipeline uses to store the SSH credentials:
+
+- Create the secret that the Pipeline uses to store the SSH credentials:
+
 ```console
 oc create secret -n orchestrator-gitops generic git-ssh-credentials \
   --from-file=ssh/id_rsa \
   --from-file=ssh/config \
   --from-file=ssh/known_hosts
 ```
+
 Note: if you change the SSH key type from the default value `rsa`, you need to update the `config` file accordingly
 
 ## Setting up GitHub Integration
+
 To begin serverless workflow development using the "Basic workflow bootstrap project" software template with GitHub as the target source control, you'll need to configure organization settings to allow read and write permissions for GitHub workflows. Follow these steps to enable the necessary permissions:
 
 1. Navigate to your organization settings on GitHub.


### PR DESCRIPTION
Resolve orchestrator-helm-chart instructions issues in [FLPATH-1219](https://issues.redhat.com/browse/FLPATH-1219)

- Show postgress SQL setup as required for both steps
- Removed step of running hack/setenv.sh from common instructions, it only works and requires for Gitops installation.
- Resolved:
In Gitops [installation page](https://github.com/parodos-dev/orchestrator-helm-chart/blob/gh-pages/gitops/README.md), revise this sentence (source of file is irrelevant:
Download the Docker configuration file for the robot account and move it under the root folder of this repository (we assume the file name is orchestrator-auth.json)