### PR TITLE
Extend quay parameters

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.20
+version: 0.2.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/tekton-pipeline.yaml
+++ b/charts/orchestrator/templates/tekton-pipeline.yaml
@@ -129,7 +129,7 @@ spec:
         - name: CONTEXT
           value: flat/$(params.workflowId)
         - name: BUILD_EXTRA_ARGS
-          value: '--authfile=/workspace/dockerconfig/.dockerconfigjson --ulimit nofile=4096:4096 --build-arg WF_RESOURCES="." --build-arg MAVEN_ARGS_APPEND="-Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false" --build-arg QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT,org.kie:kie-addons-quarkus-persistence-jdbc:999-20240317-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final'
+          value: '--authfile=/workspace/dockerconfig/.dockerconfigjson --ulimit nofile=4096:4096 --build-arg WF_RESOURCES="." --build-arg MAVEN_ARGS_APPEND="-Dkogito.persistence.type=jdbc -Dquarkus.datasource.db-kind=postgresql -Dkogito.persistence.proto.marshaller=false" --build-arg QUARKUS_EXTENSIONS=org.kie.kogito:kogito-addons-quarkus-jobs-knative-eventing:9.99.1.redhat-00003,org.kie.kogito:kogito-addons-quarkus-persistence-jdbc:9.99.1.redhat-00003,org.kie.kogito:kogito-addons-persistence-jdbc:9.99.1.redhat-00003,io.quarkus:quarkus-jdbc-postgresql:3.2.9.Final,io.quarkus:quarkus-agroal:3.2.9.Final'
     - name: push-workflow-gitops
       runAfter: ["build-gitops", "build-and-push-image"]
       taskRef:

--- a/charts/orchestrator/templates/tekton-pipeline.yaml
+++ b/charts/orchestrator/templates/tekton-pipeline.yaml
@@ -22,6 +22,12 @@ spec:
       description: Whether conversion to flat layout is needed or it's already flattened
       type: string
       default: "true"
+    - name: quayOrgName
+      description: The Quay Organization Name of the published workflow
+      type: string
+    - name: quayRepoName
+      description: The Quay Repository Name of the published workflow
+      type: string
   workspaces:
     - name: workflow-source
     - name: workflow-gitops
@@ -117,7 +123,7 @@ spec:
           workspace: docker-credentials
       params:
         - name: IMAGE
-          value: quay.io/orchestrator/serverless-workflow-$(params.workflowId):$(tasks.fetch-workflow.results.commit)
+          value: quay.io/$(params.quayOrgName)/$(params.quayRepoName):$(tasks.fetch-workflow.results.commit)
         - name: DOCKERFILE
           value: flat/workflow-builder.Dockerfile
         - name: CONTEXT


### PR DESCRIPTION
The PR adds two arguments for the tekton pipeline for specifying the organization in Quay.io and the name of the repository in case the prefix `serverless-workflow-` isn't wanted.

In addition, the pipeline updates the expected quarkus extensions.