### PR TITLE
[FLPATH-1277] Remove RHDH's secret from OCP chart

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.25
+version: 0.2.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -23,25 +23,30 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `serverlessOperator.subscription.installPlanApproval` | whether the update should be installed automatically | `"Automatic"` |
 | `serverlessOperator.subscription.name` | name of the operator package | `"serverless-operator"` |
 | `rhdhOperator.enabled` | whether the operator should be deployed by the chart | `true` |
-| `rhdhOperator.github.token` | An authentication token as expected by GitHub. Required for importing resource to the catalog, launching software templates and more. | `""` |
-| `rhdhOperator.github.clientId` | The client ID that you generated on GitHub, for GitHub authentication (requires GitHub App). | `""` |
-| `rhdhOperator.github.clientSecret` | The client secret tied to the generated client ID. | `""` |
-| `rhdhOperator.k8s.clusterToken` | Kubernetes API bearer token used for authentication. | `""` |
-| `rhdhOperator.k8s.clusterUrl` | API url of the kubernetes cluster | `""` |
+| `rhdhOperator.secretRef.name` | name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD and GitHub servers. | `"backstage-backend-auth-secret"` |
+| `rhdhOperator.secretRef.backstage.backendSecret` | Key in the secret with name defined in the 'name' field that contains the value of the Backstage backend secret. Defaults to 'BACKEND_SECRET'. It's required. | `"BACKEND_SECRET"` |
+| `rhdhOperator.secretRef.github.token` | Key in the secret with name defined in the 'name' field that contains the value of the authentication token as expected by GitHub. Required for importing resource to the catalog, launching software templates and more. Defaults to 'GITHUB_TOKEN', empty for not available. | `"GITHUB_TOKEN"` |
+| `rhdhOperator.secretRef.github.clientId` | Key in the secret with name defined in the 'name' field that contains the value of the client ID that you generated on GitHub, for GitHub authentication (requires GitHub App). Defaults to 'GITHUB_CLIENT_ID', empty for not available. | `"GITHUB_CLIENT_ID"` |
+| `rhdhOperator.secretRef.github.clientSecret` | Key in the secret with name defined in the 'name' field that contains the value of the client secret tied to the generated client ID. Defaults to 'GITHUB_CLIENT_SECRET', empty for not available. | `"GITHUB_CLIENT_SECRET"` |
+| `rhdhOperator.secretRef.k8s.clusterToken` | Key in the secret with name defined in the 'name' field that contains the value of the Kubernetes API bearer token used for authentication. Defaults to 'K8S_CLUSTER_URL', empty for not available. | `"K8S_CLUSTER_URL"` |
+| `rhdhOperator.secretRef.k8s.clusterUrl` | Key in the secret with name defined in the 'name' field that contains the value of the API URL of the kubernetes cluster. Defaults to 'K8S_CLUSTER_TOKEN', empty for not available. | `"K8S_CLUSTER_TOKEN"` |
+| `rhdhOperator.secretRef.argocd.url` | Key in the secret with name defined in the 'name' field that contains the value of the URL of the ArgoCD API server. Defaults to 'ARGOCD_URL', empty for not available. | `"ARGOCD_URL"` |
+| `rhdhOperator.secretRef.argocd.username` | Key in the secret with name defined in the 'name' field that contains the value of the username to login to ArgoCD. Defaults to 'ARGOCD_USERNAME', empty for not available. | `"ARGOCD_USERNAME"` |
+| `rhdhOperator.secretRef.argocd.password` | Key in the secret with name  defined in the 'name' field that contains the value of the password to authenticate to ArgoCD. Defaults to 'ARGOCD_PASSWORD', empty for not available. | `"ARGOCD_PASSWORD"` |
 | `rhdhOperator.subscription.namespace` | namespace where the operator should be deployed | `"rhdh-operator"` |
 | `rhdhOperator.subscription.channel` | channel of an operator package to subscribe to | `"fast"` |
 | `rhdhOperator.subscription.installPlanApproval` | whether the update should be installed automatically | `"Automatic"` |
 | `rhdhOperator.subscription.name` | name of the operator package | `"rhdh"` |
 | `rhdhPlugins.npmRegistry` |  | `""` |
 | `rhdhPlugins.scope` |  | `"@janus-idp"` |
-| `rhdhPlugins.orchestrator.package` |  | `"backstage-plugin-orchestrator@1.8.7"` |
-| `rhdhPlugins.orchestrator.integrity` |  | `"sha512-cCfXX9y0Fy+l6PfXoZ5ll2vl5buR2GD74TI4XA0uOpH+p2COj7KQg8e8gWqPBMoyvgD6JZiGEUnd/rq6Pn0XMQ=="` |
-| `rhdhPlugins.orchestrator_backend.package` |  | `"backstage-plugin-orchestrator-backend-dynamic@1.6.4"` |
-| `rhdhPlugins.orchestrator_backend.integrity` |  | `"sha512-AbTX5YGJGcpWhlPsLmsysn0TAZLEbSW2lmKu1OuhvP4iI2KQBkF6naN/0iJopEH2s0Itd+k48VN+Q7NeAPu2JA=="` |
-| `rhdhPlugins.notifications.package` |  | `"plugin-notifications@1.1.16"` |
-| `rhdhPlugins.notifications.integrity` |  | `"sha512-pmAInZ3231PGkHxpPzOIFCdftTVlk4+w5/vi5hfixPQRKNf68hm9WudsgK6Q/Rv436DHt8ZWJyAP3QWhxZR2Zw=="` |
-| `rhdhPlugins.notifications_backend.package` |  | `"plugin-notifications-backend-dynamic@1.4.3"` |
-| `rhdhPlugins.notifications_backend.integrity` |  | `"sha512-FVMmIHjAoRg+kzpEhkEjtCKgRanWHwaI9I2Jqj9/gObnF2WBIllzAPiGNxj6tkMFloLflSJc6kc9ZphttAGGcQ=="` |
+| `rhdhPlugins.orchestrator.package` |  | `"backstage-plugin-orchestrator@1.9.4"` |
+| `rhdhPlugins.orchestrator.integrity` |  | `"sha512-d0kLVkdsWMxGkOOS1wB+u24mIdF0isNY4I0F3/eR/g0lI0q+uFJ8iW+8XmyaHKqa1ZMvg5pnMljJ6thJk85nSg=="` |
+| `rhdhPlugins.orchestrator_backend.package` |  | `"backstage-plugin-orchestrator-backend-dynamic@1.6.8"` |
+| `rhdhPlugins.orchestrator_backend.integrity` |  | `"sha512-Akb9digwa3b1tOXbfbm13Z+DIZV/lBaNX0HDXhaciYE4dWPPzB17/4eT74suim9e8k4THORGVIM/GC/f2HwMNQ=="` |
+| `rhdhPlugins.notifications.package` |  | `"plugin-notifications@1.2.0"` |
+| `rhdhPlugins.notifications.integrity` |  | `"sha512-T00TKMTeLQoMTY6UnXuXpPXFN2f+w32i8qECpAe3yeZM1TJb2oe6hCNwzAdKjGGPlGPAGqc16IBpZV65rfM79Q=="` |
+| `rhdhPlugins.notifications_backend.package` |  | `"plugin-notifications-backend-dynamic@1.4.6"` |
+| `rhdhPlugins.notifications_backend.integrity` |  | `"sha512-40hMkr/+5GdapDUuYBIwzZQLpPRJQxFIrr0PFACS40lmG98XcWP6HZ7dQ+VvZ1gAFnWU9HscIrWMwrlvtZ237g=="` |
 | `postgres.serviceName` | The name of the Postgres DB service to be used by platform services. Cannot be empty. | `"sonataflow-psql-postgresql"` |
 | `postgres.serviceNamespace` | The namespace of the Postgres DB service to be used by platform services. | `"sonataflow-infra"` |
 | `postgres.authSecret.name` | name of existing secret to use for PostgreSQL credentials. | `"sonataflow-psql-postgresql"` |
@@ -55,10 +60,7 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `orchestrator.sonataPlatform.resources.limits.cpu` |  | `"500m"` |
 | `tekton.enabled` | whether to create the Tekton pipeline resources | `false` |
 | `argocd.enabled` | whether to install the ArgoCD plugin and create the orchestrator AppProject | `false` |
-| `argocd.url` |  | `""` |
 | `argocd.namespace` |  | `"orchestrator-gitops"` |
-| `argocd.username` |  | `"admin"` |
-| `argocd.password` |  | `""` |
 
 
 

--- a/charts/orchestrator/templates/NOTES.txt
+++ b/charts/orchestrator/templates/NOTES.txt
@@ -56,6 +56,10 @@ Helm Release {{ .Release.Name }} installed in namespace {{ .Release.Namespace }}
 {{- $argocdInstalled = $yes }}
 {{- end }}
 
+{{- $workflowNamespace := include "get-workflow-namespace" . }}
+{{- $gitopsNamespace := include "get-argocd-namespace" . }}
+
+
 Components                   Installed   Namespace
 ====================================================================
 Backstage                    {{ $backstageInstalled }}        {{ .Values.rhdhOperator.subscription.namespace }}
@@ -64,12 +68,12 @@ Red Hat Serverless Operator  {{ $serverlessOperatorInstalled }}        {{ .Value
 KnativeServing               {{ $knativeServingInstalled }}        knative-serving
 KnativeEventing              {{ $knativeEventingInstalled }}        knative-eventing
 SonataFlow Operator          {{ $sonataFlowOperatorInstalled }}        {{ .Values.sonataFlowOperator.subscription.namespace }}
-SonataFlowPlatform           {{ $sonataFlowPlatformInstalled }}        {{ .Values.orchestrator.namespace }}
-Data Index Service           {{ $sonataFlowPlatformInstalled }}        {{ .Values.orchestrator.namespace }}
-Job Service                  {{ $sonataFlowPlatformInstalled }}        {{ .Values.orchestrator.namespace }}
-Tekton pipeline              {{ $tektonPipelineInstalled }}        {{ .Values.argocd.namespace }}
-Tekton task                  {{ $tektonTaskInstalled }}        {{ .Values.argocd.namespace }}
-ArgoCD project               {{ $argocdInstalled }}        {{ .Values.argocd.namespace }}
+SonataFlowPlatform           {{ $sonataFlowPlatformInstalled }}        {{ $workflowNamespace }}
+Data Index Service           {{ $sonataFlowPlatformInstalled }}        {{ $workflowNamespace }}
+Job Service                  {{ $sonataFlowPlatformInstalled }}        {{ $workflowNamespace }}
+Tekton pipeline              {{ $tektonPipelineInstalled }}        {{ $gitopsNamespace }}
+Tekton task                  {{ $tektonTaskInstalled }}        {{ $gitopsNamespace }}
+ArgoCD project               {{ $argocdInstalled }}        {{ $gitopsNamespace }}
 {{/* Empty line */}}
 ====================================================================
 Prerequisites check:
@@ -105,13 +109,13 @@ Run the following commands to wait until the services are ready:
   oc wait -n {{ .Values.sonataFlowOperator.subscription.namespace }} deploy/logic-operator-rhel8-controller-manager --for=condition=Available {{ $timeout }}
 {{- end }}
 {{- if eq $sonataFlowPlatformInstalled $yes }}
-  oc wait -n {{ .Values.orchestrator.namespace }} sonataflowplatform/sonataflow-platform --for=condition=Succeed {{ $timeout }}
+  oc wait -n {{ $workflowNamespace }} sonataflowplatform/sonataflow-platform --for=condition=Succeed {{ $timeout }}
 {{- end }}
 {{- if eq $sonataFlowPlatformInstalled $yes }}
-  oc wait -n {{ .Values.orchestrator.namespace }} deploy/sonataflow-platform-data-index-service --for=condition=Available {{ $timeout }}
+  oc wait -n {{ $workflowNamespace }} deploy/sonataflow-platform-data-index-service --for=condition=Available {{ $timeout }}
 {{- end }}
 {{- if eq $sonataFlowPlatformInstalled $yes }}
-  oc wait -n {{ .Values.orchestrator.namespace }} deploy/sonataflow-platform-jobs-service --for=condition=Available {{ $timeout }}
+  oc wait -n {{ $workflowNamespace }} deploy/sonataflow-platform-jobs-service --for=condition=Available {{ $timeout }}
 {{- end }}
 {{- if eq $postgresBackstageInstalled $yes }}
   oc wait -n {{ .Values.rhdhOperator.subscription.namespace }} pod/backstage-psql-backstage-0 --for=condition=Ready {{ $timeout }}

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -52,7 +52,7 @@
 
 
 {{- define "install-tekton-task" -}}
-  {{- if and (.Values.tekton.enabled) (ne .Values.rhdhOperator.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Task") }}
+  {{- if and (.Values.tekton.enabled) (ne .Values.rhdhOperator.secretRef.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Task") }}
         {{- "true" -}}
     {{- else }}
         {{- "false" -}}
@@ -60,7 +60,7 @@
 {{- end -}}
 
 {{- define "install-tekton-pipeline" -}}
-  {{- if and (.Values.tekton.enabled) (ne .Values.rhdhOperator.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Pipeline") }}
+  {{- if and (.Values.tekton.enabled) (ne .Values.rhdhOperator.secretRef.k8s.clusterToken "") (.Capabilities.APIVersions.Has "tekton.dev/v1/Pipeline") }}
         {{- "true" -}}
     {{- else }}
         {{- "false" -}}
@@ -74,3 +74,45 @@
         {{- "false" -}}
     {{- end -}}
 {{- end -}}
+
+
+{{- define "get-namespace-with-label" -}}
+    {{- $paramValue:= index . 0 -}}
+    {{- $matchingLabel:= index . 1 -}}
+    {{- if $paramValue -}}
+        {{- $paramValue -}}
+    {{- else -}}
+        {{- $ns:= "" }}
+        {{- $list:= lookup "v1" "Namespace" "" "" -}}
+        {{- range (dig "items" (dict "" "") $list) }}
+            {{- $labels:= dig "metadata" "labels" (dict "" "" ) .  -}}
+            {{- if (hasKey $labels $matchingLabel ) }}
+                {{- if not $ns }}
+                    {{- $ns = dig "metadata" "name" "" . -}}
+                {{- else -}}
+                    {{- fail (printf "More than one namespace found with label %s: %s and %s" $matchingLabel $ns (dig "metadata" "name" "" .) )}}
+                {{- end }}
+            {{- end -}}
+        {{- end -}}
+        {{- if not $ns -}}
+            {{- fail (printf "No namespace found with label '%s'. Please follow the installation instructions to properly configure the environment" $matchingLabel) -}}
+        {{- end }}
+        {{- $ns }}
+    {{- end -}}
+{{- end -}}
+
+{{- define "get-workflow-namespace" -}}
+    {{- if (not (hasKey . "workflowNamespace" ) ) -}}
+        {{- $workflowNamespace := include "get-namespace-with-label" (list .Values.orchestrator.namespace "rhdh.redhat.com/workflow-namespace")  }}
+        {{- $_ := set . "workflowNamespace" $workflowNamespace }}
+    {{- end -}}
+    {{- .workflowNamespace -}}
+{{- end -}}
+
+{{- define "get-argocd-namespace" -}}
+    {{- if (not (hasKey . "argoCDNamespace" ) ) -}}
+        {{- $argoCDNamespace := include "get-namespace-with-label" (list .Values.argocd.namespace "rhdh.redhat.com/argocd-namespace")  }}
+        {{- $_ := set . "argoCDNamespace" $argoCDNamespace }}
+    {{- end -}}
+    {{- .argoCDNamespace -}}
+{{- end -}}s

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -84,20 +84,24 @@
     {{- else -}}
         {{- $ns:= "" }}
         {{- $list:= lookup "v1" "Namespace" "" "" -}}
-        {{- range (dig "items" (dict "" "") $list) }}
-            {{- $labels:= dig "metadata" "labels" (dict "" "" ) .  -}}
-            {{- if (hasKey $labels $matchingLabel ) }}
-                {{- if not $ns }}
-                    {{- $ns = dig "metadata" "name" "" . -}}
-                {{- else -}}
-                    {{- fail (printf "More than one namespace found with label %s: %s and %s" $matchingLabel $ns (dig "metadata" "name" "" .) )}}
-                {{- end }}
+        {{- if gt 0 (len (dig "items" (dict "" "") $list ) )}}
+            {{- range (dig "items" (dict "" "") $list) }}
+                {{- $labels:= dig "metadata" "labels" (dict "" "" ) .  -}}
+                {{- if (hasKey $labels $matchingLabel ) }}
+                    {{- if not $ns }}
+                        {{- $ns = dig "metadata" "name" "" . -}}
+                    {{- else -}}
+                        {{- fail (printf "More than one namespace found with label %s: %s and %s" $matchingLabel $ns (dig "metadata" "name" "" .) )}}
+                    {{- end }}
+                {{- end -}}
             {{- end -}}
+            {{- if not $ns -}}
+                {{- fail (printf "No namespace found with label '%s'. Please follow the installation instructions to properly configure the environment" $matchingLabel) -}}
+            {{- end }}
+            {{- $ns }}
+        {{- else -}}
+            {{- fail "No namespaces found" }}
         {{- end -}}
-        {{- if not $ns -}}
-            {{- fail (printf "No namespace found with label '%s'. Please follow the installation instructions to properly configure the environment" $matchingLabel) -}}
-        {{- end }}
-        {{- $ns }}
     {{- end -}}
 {{- end -}}
 

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -38,7 +38,7 @@
 
 
 {{- define "cluster.domain" -}}
-    {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1/Ingress" -}}  
+    {{- if .Capabilities.APIVersions.Has "config.openshift.io/v1/Ingress" -}}
         {{- $cluster := (lookup "config.openshift.io/v1" "Ingress" "" "cluster") -}}
         {{- if and (hasKey $cluster "spec") (hasKey $cluster.spec "domain") -}}
             {{- printf "%s" $cluster.spec.domain -}}

--- a/charts/orchestrator/templates/argocd-project.yaml
+++ b/charts/orchestrator/templates/argocd-project.yaml
@@ -1,9 +1,10 @@
 {{- if eq "true" (include "install-argocd-project" .) }}
+{{- $gitopsNamespace := include "get-argocd-namespace" . }}
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: orchestrator-gitops
-  namespace: {{ .Values.argocd.namespace }}
+  namespace: {{ $gitopsNamespace }}
 spec:
   destinations:
   - name: '*'

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -172,8 +172,11 @@ data:
     {{- end }}
   {{- end }}
   {{- if and .Values.argocd.enabled
-          ( (and .Values.rhdhOperator.secretRef.argocd.url (dig "data" .Values.rhdhOperator.secretRef.argocd.url "" $secret ) )
-            (and .Values.rhdhOperator.secretRef.argocd.username (dig "data" .Values.rhdhOperator.secretRef.argocd.password "" $secret) ) ) }}
+        ( and
+            (and (.Values.rhdhOperator.secretRef.argocd.url) (dig "data" .Values.rhdhOperator.secretRef.argocd.url "" $secret ) )
+            (and (.Values.rhdhOperator.secretRef.argocd.username) (dig "data" .Values.rhdhOperator.secretRef.argocd.password "" $secret) )
+        )
+  }}
       - disabled: false
         package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
         pluginConfig:
@@ -228,7 +231,7 @@ data:
         pluginConfig:
           orchestrator:
             dataIndexService:
-              url: http://sonataflow-platform-data-index-service.{{ .Values.orchestrator.namespace }}
+              url: http://sonataflow-platform-data-index-service.{{- include "get-workflow-namespace" . }}
       - disabled: false
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.orchestrator.package }}"
         integrity: {{ .Values.rhdhPlugins.orchestrator.integrity }}

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -5,6 +5,8 @@ kind: Backstage
 metadata:
   name: backstage
   namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  annotations:
+    "meta.helm.sh/release-name": {{ .Release.Name}}
 spec:
   application:
     appConfig:
@@ -15,17 +17,24 @@ spec:
     dynamicPluginsConfigMapName: dynamic-plugins-rhdh
     extraEnvs:
       secrets:
-        - name: backstage-backend-auth-secret
+        - name: {{ .Values.rhdhOperator.secretRef.name }}
     replicas: 1
 {{- end }}
+
 {{- if .Values.rhdhOperator.enabled }}
-  {{- $unmanagedNamespaceExists := include "unmanaged-resource-exists" (list "v1" "Namespace" "" .Values.rhdhOperator.subscription.namespace .Release.Name .Capabilities.APIVersions ) }}
-  {{- if and (eq $unmanagedNamespaceExists "false") .Values.rhdhOperator.enabled }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.rhdhOperator.subscription.namespace }}
+  {{- if not .Values.rhdhOperator.secretRef.name }} {
+    {{- fail "Backstage's secret name defined in 'rhdhOperator.secretRef.name' is required" }}
+  {{- end }}
+  {{- $secret := lookup "v1" "Secret" .Values.rhdhOperator.subscription.namespace .Values.rhdhOperator.secretRef.name }}
+  {{- if not $secret }}
+    {{- fail (printf "Secret %s not found in namespace %s" .Values.rhdhOperator.secretRef.name .Values.rhdhOperator.subscription.namespace ) }}
+  {{- end }}
+  {{ if not .Values.rhdhOperator.secretRef.backstage.backendSecret }}
+    {{ fail printf "Backend secret key not defined in secret '%s' for Backstage. Please ensure that the value key 'rhdhOperator.secretRef.backstage.backendSecret' has been populated and the value matches the key in the secret" .Values.rhdhOperator.secretRef.name }}
+  {{- end }}
+  {{- if not (dig "data" .Values.rhdhOperator.secretRef.backstage.backendSecret "" $secret) }}
+    {{ fail (printf "Backend secret key %s not found in secret '%s' for Backstage. Please ensure that the value key 'rhdhOperator.secretRef.backstage.backendSecret' matches the key in the secret: %s" .Values.rhdhOperator.secretRef.backstage.backendSecret .Values.rhdhOperator.secretRef.name ($secret|toPrettyJson) )}}
+  {{- end }}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -34,7 +43,6 @@ metadata:
   namespace: {{ .Values.rhdhOperator.subscription.namespace }}
 spec: {}
 ---
-  {{- end }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -46,34 +54,9 @@ spec:
   name: {{ .Values.rhdhOperator.subscription.name }}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+
+  {{- if .Values.rhdhPlugins.npmRegistry }}
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: backstage-backend-auth-secret
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
-stringData:
-  {{- $old_secret := lookup "v1" "Secret" .Values.rhdhOperator.subscription.namespace "backstage-backend-auth-secret" }}
-  {{- $generated_secret := randAlphaNum 24 | nospace | b64enc }}
-  BACKEND_SECRET: {{ $old_secret | dig "data" "BACKEND_SECRET" $generated_secret | b64dec }}
-  {{- if ne .Values.rhdhOperator.k8s.clusterToken "" }}
-  K8S_CLUSTER_URL: {{ .Values.rhdhOperator.k8s.clusterUrl }}
-  K8S_CLUSTER_TOKEN: {{ .Values.rhdhOperator.k8s.clusterToken }}
-  {{- end }}
-  {{- if .Values.argocd.enabled }}
-  ARGOCD_URL: {{ .Values.argocd.url }}
-  ARGOCD_USERNAME: {{ .Values.argocd.username }}
-  ARGOCD_PASSWORD: {{ .Values.argocd.password }}
-  {{- end }}
-  {{- if ne .Values.rhdhOperator.github.token "" }}
-  GITHUB_TOKEN: {{ .Values.rhdhOperator.github.token }}
-  {{- end }}
-  {{- if ne .Values.rhdhOperator.github.clientId "" }}
-  GITHUB_CLIENT_ID: {{ .Values.rhdhOperator.github.clientId }}
-  GITHUB_CLIENT_SECRET: {{ .Values.rhdhOperator.github.clientSecret }}
-  {{- end }}
----
-  {{- if ne .Values.rhdhPlugins.npmRegistry "" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -83,8 +66,8 @@ type: Opaque
 stringData:
   .npmrc: |
     registry={{ .Values.rhdhPlugins.npmRegistry }}
----
   {{- end }}
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -98,9 +81,10 @@ data:
     backend:
       auth:
         keys:
-          - secret: "${BACKEND_SECRET}"
-      baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.namespace }}.{{ include "cluster.domain" . }}      
-      csp:        
+          - secret: {{ printf "${%s}" .Values.rhdhOperator.secretRef.backstage.backendSecret }}
+
+      baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.namespace }}.{{ include "cluster.domain" . }}
+      csp:
         script-src: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
         script-src-elem: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
         connect-src: ["'self'", 'http:', 'https:', 'data:']
@@ -124,7 +108,8 @@ data:
     includes:
       - dynamic-plugins.default.yaml
     plugins:
-  {{- if ne .Values.rhdhOperator.k8s.clusterToken "" }}
+  {{- if and (and .Values.rhdhOperator.secretRef.k8s.clusterToken (dig "data" .Values.rhdhOperator.secretRef.k8s.clusterToken "" $secret ) )
+             (and .Values.rhdhOperator.secretRef.k8s.clusterUrl   (dig "data" .Values.rhdhOperator.secretRef.k8s.clusterUrl "" $secret ) ) }}
       - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
         disabled: false
         pluginConfig:
@@ -148,10 +133,10 @@ data:
               - type: 'config'
                 clusters:
                   - name: 'OpenShift Orchestrator Demo'
-                    url: ${K8S_CLUSTER_URL}
+                    url: {{ printf "${%s}" .Values.rhdhOperator.secretRef.k8s.clusterUrl }}
                     authProvider: 'serviceAccount'
                     skipTLSVerify: true
-                    serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+                    serviceAccountToken: {{ printf "${%s}" .Values.rhdhOperator.secretRef.k8s.clusterToken }}
       - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
         disabled: false
         pluginConfig:
@@ -168,6 +153,7 @@ data:
                         anyOf:
                           - hasAnnotation: backstage.io/kubernetes-id
                           - hasAnnotation: backstage.io/kubernetes-namespace
+    {{- if .Values.tekton.enabled }}
       - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-tekton
         disabled: false
         pluginConfig:
@@ -183,8 +169,11 @@ data:
                       if:
                         allOf:
                           - isTektonCIAvailable
+    {{- end }}
   {{- end }}
-  {{- if .Values.argocd.enabled }}
+  {{- if and .Values.argocd.enabled
+          ( (and .Values.rhdhOperator.secretRef.argocd.url (dig "data" .Values.rhdhOperator.secretRef.argocd.url "" $secret ) )
+            (and .Values.rhdhOperator.secretRef.argocd.username (dig "data" .Values.rhdhOperator.secretRef.argocd.password "" $secret) ) ) }}
       - disabled: false
         package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
         pluginConfig:
@@ -192,9 +181,9 @@ data:
             appLocatorMethods:
             - instances:
               - name: main
-                url: ${ARGOCD_URL}
-                username: ${ARGOCD_USERNAME}
-                password: ${ARGOCD_PASSWORD}
+                url: {{ printf "${%s}" .Values.rhdhOperator.secretRef.argocd.url }}
+                username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.argocd.username }}
+                password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.argocd.password }}
               type: config
       - disabled: false
         package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd
@@ -228,9 +217,9 @@ data:
             appLocatorMethods:
             - instances:
               - name: main
-                url: ${ARGOCD_URL}
-                username: ${ARGOCD_USERNAME}
-                password: ${ARGOCD_PASSWORD}
+                url: {{ printf "${%s}" .Values.rhdhOperator.secretRef.argocd.url }}
+                username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.argocd.username }}
+                password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.argocd.password }}
               type: config
   {{- end }}
       - disabled: false
@@ -239,7 +228,7 @@ data:
         pluginConfig:
           orchestrator:
             dataIndexService:
-              url: http://sonataflow-platform-data-index-service.{{ .Values.orchestrator.namespace }}                          
+              url: http://sonataflow-platform-data-index-service.{{ .Values.orchestrator.namespace }}
       - disabled: false
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.orchestrator.package }}"
         integrity: {{ .Values.rhdhPlugins.orchestrator.integrity }}
@@ -289,20 +278,21 @@ metadata:
   namespace: {{ .Values.rhdhOperator.subscription.namespace }}
 data:
   app-config-auth.gh.yaml: |
-  {{- if ne .Values.rhdhOperator.github.token "" }}
+  {{- if and .Values.rhdhOperator.secretRef.github.token (dig "data" .Values.rhdhOperator.secretRef.github.token "" $secret) }}
     integrations:
       github:
         - host: github.com
-          token: ${GITHUB_TOKEN}
+          token: {{ printf "${%s}" .Values.rhdhOperator.secretRef.github.token }}
     auth:
       environment: development
   {{- end }}
-  {{- if ne .Values.rhdhOperator.github.clientId "" }}
+  {{- if and (and .Values.rhdhOperator.secretRef.github.clientId (dig "data" .Values.rhdhOperator.secretRef.github.clientId "" $secret) )
+             (and .Values.rhdhOperator.secretRef.github.clientSecret  (dig "data" .Values.rhdhOperator.secretRef.github.clientSecret "" $secret  ) ) }}
       providers:
         github:
           development:
-            clientId: ${GITHUB_CLIENT_ID}
-            clientSecret: ${GITHUB_CLIENT_SECRET}
+            clientId: {{ printf "${%s}" .Values.rhdhOperator.secretRef.github.clientId }}
+            clientSecret: {{ printf "${%s}" .Values.rhdhOperator.secretRef.github.clientSecret }}
   {{- end }}
 ---
 kind: ConfigMap
@@ -335,5 +325,8 @@ data:
           target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/basic-workflow/template.yaml
         - type: url
           target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/complex-assessment-workflow/template.yaml
-  {{- include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "rhdh.redhat.com" "groupVersion" "v1alpha1" "kind" "Backstage" "kinds" "backstages" "targetNamespace" .Values.rhdhOperator.subscription.namespace "resourceName" "backstage" "isEnabled" .Values.rhdhOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "rhdh.redhat.com/v1alpha1/Backstage") "manifest" (include "backstage-manifest" . | b64enc )) }}
+  {{- $unmanagedNamespaceExists := include "unmanaged-resource-exists" (list "rhdh.redhat.com/v1alpha1" "Backstage" .Values.rhdhOperator.subscription.namespace "backstage" .Release.Name .Capabilities.APIVersions ) }}
+  {{- if eq $unmanagedNamespaceExists "false" }}
+    {{- include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "rhdh.redhat.com" "groupVersion" "v1alpha1" "kind" "Backstage" "kinds" "backstages" "targetNamespace" .Values.rhdhOperator.subscription.namespace "resourceName" "backstage" "isEnabled" .Values.rhdhOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "rhdh.redhat.com/v1alpha1/Backstage") "manifest" (include "backstage-manifest" . | b64enc )) }}
+  {{- end }}
 {{- end }}

--- a/charts/orchestrator/templates/sonataflows.yaml
+++ b/charts/orchestrator/templates/sonataflows.yaml
@@ -1,4 +1,5 @@
 {{- define "sonataFlowClusterPlatform-manifest" }}
+{{- $workflowNamespace := include "get-workflow-namespace" . }}
 ---
 apiVersion: sonataflow.org/v1alpha08
 kind: SonataFlowClusterPlatform
@@ -9,15 +10,16 @@ metadata:
 spec:
   platformRef:
     name: sonataflow-platform
-    namespace: {{ .Values.orchestrator.namespace }}
+    namespace: {{ $workflowNamespace }}
 {{- end }}
 {{- define "sonataFlowPlatform-manifest" }}
+{{- $workflowNamespace := include "get-workflow-namespace" . }}
 ---
 apiVersion: sonataflow.org/v1alpha08
 kind: SonataFlowPlatform
 metadata:
   name: sonataflow-platform
-  namespace: {{ .Values.orchestrator.namespace }}
+  namespace: {{ $workflowNamespace }}
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name}}
 spec:
@@ -57,6 +59,7 @@ spec:
             name: {{ .Values.postgres.serviceName }}
             namespace: {{ .Values.postgres.serviceNamespace }}
 {{- end }}
+{{- $workflowNamespace := include "get-workflow-namespace" . }}
 ## Manifests
 {{ include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "sonataflow.org" "groupVersion" "v1alpha08" "kind" "SonataFlowClusterPlatform" "kinds" "sonataflowclusterplatforms" "resourceName" "cluster-platform" "isEnabled" .Values.sonataFlowOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "sonataflow.org/v1alpha08/SonataFlowClusterPlatform") "manifest" (include "sonataFlowClusterPlatform-manifest" . | b64enc )) }}
-{{ include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "sonataflow.org" "groupVersion" "v1alpha08" "kind" "SonataFlowPlatform" "kinds" "sonataflowplatforms" "targetNamespace" .Values.orchestrator.namespace "resourceName" "sonataflow-platform" "isEnabled" .Values.sonataFlowOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "sonataflow.org/v1alpha08/SonataFlowClusterPlatform") "manifest" (include "sonataFlowPlatform-manifest" . | b64enc )) }}
+{{ include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "sonataflow.org" "groupVersion" "v1alpha08" "kind" "SonataFlowPlatform" "kinds" "sonataflowplatforms" "targetNamespace" $workflowNamespace "resourceName" "sonataflow-platform" "isEnabled" .Values.sonataFlowOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "sonataflow.org/v1alpha08/SonataFlowClusterPlatform") "manifest" (include "sonataFlowPlatform-manifest" . | b64enc )) }}

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -179,8 +179,7 @@
             "title": "The rhdhOperator Schema",
             "required": [
                 "enabled",
-                "github",
-                "k8s",
+                "secretRef",
                 "subscription"
             ],
             "properties": {
@@ -192,78 +191,140 @@
                         true
                     ]
                 },
-                "github": {
+                "secretRef": {
                     "type": "object",
                     "default": {},
-                    "title": "The github Schema",
+                    "title": "The secretRef Schema",
                     "required": [
-                        "token",
-                        "clientId",
-                        "clientSecret"
+                        "name",
+                        "github",
+                        "k8s",
+                        "argocd"
                     ],
                     "properties": {
-                        "token": {
+                        "name": {
                             "type": "string",
-                            "default": "",
-                            "title": "The token Schema",
+                            "default": "backstage-backend-auth-secret",
+                            "title": "Name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD and GitHub servers.",
                             "examples": [
-                                ""
+                                "backstage-backend-auth-secret"
                             ]
                         },
-                        "clientId": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The clientId Schema",
-                            "examples": [
-                                ""
-                            ]
+                        "github": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The github Schema",
+                            "required": [
+                                "token",
+                                "clientId",
+                                "clientSecret"
+                            ],
+                            "properties": {
+                                "token": {
+                                    "type": "string",
+                                    "default": "GITHUB_TOKEN",
+                                    "title": "The token Schema",
+                                    "examples": [
+                                        "GITHUB_TOKEN"
+                                    ]
+                                },
+                                "clientId": {
+                                    "type": "string",
+                                    "default": "GITHUB_CLIENT_ID",
+                                    "title": "The clientId Schema",
+                                    "examples": [
+                                        "GITHUB_CLIENT_ID"
+                                    ]
+                                },
+                                "clientSecret": {
+                                    "type": "string",
+                                    "default": "GITHUB_CLIENT_SECRET",
+                                    "title": "The clientSecret Schema",
+                                    "examples": [
+                                        "GITHUB_CLIENT_SECRET"
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "token": "GITHUB_TOKEN",
+                                "clientId": "GITHUB_CLIENT_ID",
+                                "clientSecret": "GITHUB_CLIENT_SECRET"
+                            }]
                         },
-                        "clientSecret": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The clientSecret Schema",
-                            "examples": [
-                                ""
-                            ]
+                        "k8s": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The k8s Schema",
+                            "required": [
+                                "clusterToken",
+                                "clusterUrl"
+                            ],
+                            "properties": {
+                                "clusterToken": {
+                                    "type": "string",
+                                    "default": "K8S_CLUSTER_TOKEN",
+                                    "title": "The clusterToken Schema",
+                                    "examples": [
+                                        "K8S_CLUSTER_TOKEN"
+                                    ]
+                                },
+                                "clusterUrl": {
+                                    "type": "string",
+                                    "default": "K8S_CLUSTER_URL",
+                                    "title": "The clusterUrl Schema",
+                                    "examples": [
+                                        "K8S_CLUSTER_URL"
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "clusterToken": "K8S_CLUSTER_TOKEN",
+                                "clusterUrl": "K8S_CLUSTER_URL"
+                            }]
+                            }
+                        },
+                        "argocd": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The argocd Schema",
+                            "required": [
+                                "url",
+                                "username",
+                                "password"
+                            ],
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "default": "ARGOCD_URL",
+                                    "title": "The url Schema",
+                                    "examples": [
+                                        "ARGOCD_URL"
+                                    ]
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "default": "ARGOCD_USERNAME",
+                                    "title": "The username Schema",
+                                    "examples": [
+                                        "ARGOCD_USERNAME"
+                                    ]
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "default": "ARGOCD_PASSWORD",
+                                    "title": "The password Schema",
+                                    "examples": [
+                                        "ARGOCD_PASSWORD"
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "username":"ARGOCD_USERNAME",
+                                "password":"ARGOCD_PASSWORD",
+                                "url":"ARGOCD_URL"
+                            }]
                         }
                     },
-                    "examples": [{
-                        "token": "",
-                        "clientId": "",
-                        "clientSecret": ""
-                    }]
-                },
-                "k8s": {
-                    "type": "object",
-                    "default": {},
-                    "title": "The k8s Schema",
-                    "required": [
-                        "clusterToken",
-                        "clusterUrl"
-                    ],
-                    "properties": {
-                        "clusterToken": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The clusterToken Schema",
-                            "examples": [
-                                ""
-                            ]
-                        },
-                        "clusterUrl": {
-                            "type": "string",
-                            "default": "",
-                            "title": "The clusterUrl Schema",
-                            "examples": [
-                                ""
-                            ]
-                        }
-                    },
-                    "examples": [{
-                        "clusterToken": "",
-                        "clusterUrl": ""
-                    }]
-                },
                 "subscription": {
                     "type": "object",
                     "default": {},
@@ -318,14 +379,22 @@
             },
             "examples": [{
                 "enabled": true,
-                "github": {
-                    "token": "",
-                    "clientId": "",
-                    "clientSecret": ""
-                },
-                "k8s": {
-                    "clusterToken": "",
-                    "clusterUrl": ""
+                "secretRef": {
+                    "name":"backstage-backend-auth-secret",
+                    "github": {
+                        "token": "GITHUB_TOKEN",
+                        "clientId": "GITHUB_CLIENT_ID",
+                        "clientSecret": "GITHUB_CLIENT_SECRET"
+                    },
+                    "k8s": {
+                        "clusterToken": "K8S_CLUSTER_TOKEN",
+                        "clusterUrl": "K8S_CLUSTER_URL"
+                    },
+                    "argocd": {
+                        "username":"ARGOCD_USERNAME",
+                        "password":"ARGOCD_PASSWORD",
+                        "url":"ARGOCD_URL"
+                    }
                 },
                 "subscription": {
                     "namespace": "rhdh-operator",
@@ -764,10 +833,7 @@
             "title": "The argocd Schema",
             "required": [
                 "enabled",
-                "url",
-                "namespace",
-                "username",
-                "password"
+                "namespace"
             ],
             "properties": {
                 "enabled": {
@@ -813,10 +879,7 @@
             },
             "examples": [{
                 "enabled": false,
-                "url": "",
-                "namespace": "orchestrator-gitops",
-                "username": "admin",
-                "password": ""
+                "namespace": "orchestrator-gitops"
             }]
         }
     },
@@ -841,14 +904,25 @@
         },
         "rhdhOperator": {
             "enabled": true,
-            "github": {
-                "token": "",
-                "clientId": "",
-                "clientSecret": ""
-            },
-            "k8s": {
-                "clusterToken": "",
-                "clusterUrl": ""
+            "secretRef": {
+                "name": "backstage-backend-auth-secret",
+                "backstage": {
+                    "backendSecret": "BACKEND_SECRET"
+                },
+                "github": {
+                    "token": "GITHUB_TOKEN",
+                    "clientId": "GITHUB_CLIENT_ID",
+                    "clientSecret": "GITHUB_CLIENT_SECRET"
+                },
+                "k8s": {
+                    "clusterToken": "K8S_CLUSTER_TOKEN",
+                    "clusterUrl": "K8S_CLUSTER_URL"
+                },
+                "argocd": {
+                    "url": "ARGOCD_URL",
+                    "username":"ARGOCD_USERNAME",
+                    "password":"ARGOCD_PASSWORD"
+                }
             },
             "subscription": {
                 "namespace": "rhdh-operator",

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -16,13 +16,21 @@ serverlessOperator:
 
 rhdhOperator:
   enabled: true # whether the operator should be deployed by the chart
-  github:
-    token: "" # An authentication token as expected by GitHub. Required for importing resource to the catalog, launching software templates and more.
-    clientId: "" # The client ID that you generated on GitHub, for GitHub authentication (requires GitHub App).
-    clientSecret: "" # The client secret tied to the generated client ID.
-  k8s:
-    clusterToken: "" # Kubernetes API bearer token used for authentication.
-    clusterUrl: "" # API url of the kubernetes cluster
+  secretRef:
+    name: backstage-backend-auth-secret # name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD and GitHub servers.
+    backstage:
+      backendSecret: BACKEND_SECRET # Key in the secret with name defined in the 'name' field that contains the value of the Backstage backend secret. Defaults to 'BACKEND_SECRET'. It's required.
+    github: #GitHub specific configuration fields that are injected to the backstage instance to allow the plugin to communicate with GitHub.
+      token: GITHUB_TOKEN # Key in the secret with name defined in the 'name' field that contains the value of the authentication token as expected by GitHub. Required for importing resource to the catalog, launching software templates and more. Defaults to 'GITHUB_TOKEN', empty for not available.
+      clientId: GITHUB_CLIENT_ID # Key in the secret with name defined in the 'name' field that contains the value of the client ID that you generated on GitHub, for GitHub authentication (requires GitHub App). Defaults to 'GITHUB_CLIENT_ID', empty for not available.
+      clientSecret: GITHUB_CLIENT_SECRET # Key in the secret with name defined in the 'name' field that contains the value of the client secret tied to the generated client ID. Defaults to 'GITHUB_CLIENT_SECRET', empty for not available.
+    k8s: # Kubernetes specific configuration fields that are injected to the backstage instance to allow the plugin to communicate with the Kubernetes API Server.
+      clusterToken: K8S_CLUSTER_URL # Key in the secret with name defined in the 'name' field that contains the value of the Kubernetes API bearer token used for authentication. Defaults to 'K8S_CLUSTER_URL', empty for not available.
+      clusterUrl: K8S_CLUSTER_TOKEN # Key in the secret with name defined in the 'name' field that contains the value of the API URL of the kubernetes cluster. Defaults to 'K8S_CLUSTER_TOKEN', empty for not available.
+    argocd: # ArgoCD specific configuration fields that are injected to the backstage instance to allow the plugin to communicate with ArgoCD. Note that ArgoCD must be deployed beforehand and the argocd.enabled field must be set to true as well.
+      url: ARGOCD_URL # Key in the secret with name defined in the 'name' field that contains the value of the URL of the ArgoCD API server. Defaults to 'ARGOCD_URL', empty for not available.
+      username: ARGOCD_USERNAME # Key in the secret with name defined in the 'name' field that contains the value of the username to login to ArgoCD. Defaults to 'ARGOCD_USERNAME', empty for not available.
+      password: ARGOCD_PASSWORD # Key in the secret with name  defined in the 'name' field that contains the value of the password to authenticate to ArgoCD. Defaults to 'ARGOCD_PASSWORD', empty for not available.
   subscription:
     namespace: rhdh-operator # namespace where the operator should be deployed
     channel: fast # channel of an operator package to subscribe to
@@ -70,7 +78,4 @@ tekton:
 
 argocd:
   enabled: false # whether to install the ArgoCD plugin and create the orchestrator AppProject
-  url: ""
   namespace: orchestrator-gitops
-  username: admin
-  password: ""

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -63,7 +63,7 @@ postgres:
   database: sonataflow # existing database instance used by data index and job service
 
 orchestrator:
-  namespace: sonataflow-infra # namespace where the data index, job service and workflows are deployed
+  namespace: "" # Namespace where sonataflow's workflows run. The value is captured when running the configure_environment.sh script and stored as an annotation in the `orchestrator` namespace. User can override the value by populating this field. Defaults to `sonataflow-infra` if none is provided either via annotation or this field being empty.
   sonataPlatform:
     resources:
       requests:
@@ -78,4 +78,4 @@ tekton:
 
 argocd:
   enabled: false # whether to install the ArgoCD plugin and create the orchestrator AppProject
-  namespace: orchestrator-gitops
+  namespace: "" # Defines the namespace where the orchestrator's instance of ArgoCD is deployed. The value is captured when running setup.sh script and stored as an annotation in the `orchestrator` namespace. User can override the value by populating this field. Defaults to `orchestrator-gitops` if none is provided either via annotation or this field being empty.


### PR DESCRIPTION
* Removes the RHDH secret that hosts the GitHub, K8s and ArgoCD credentials.
* At templating time, the key existence is validated against the deployed secret rather than validate that the `values.yaml` entry contains a value. This ensures that the snippets of code that are currently embedded based on the secret's key existence in the `values.yaml` file remain consistent with the new change.
* Rebuilt the README.md using frigate following the instructions in the documentation.
* Note that with this change, the chart will fail to deploy if the RHDH secret does not exist or it does not contain the backstage's backend secret (`BACKEND_SECRET`), which is the only mandatory entry required in the secret.

@masayag PTAL.