### PR TITLE
Add sonataflow infra as default in values.yaml

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.26
+version: 0.2.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -678,7 +678,7 @@
             "properties": {
                 "namespace": {
                     "type": "string",
-                    "default": "",
+                    "default": "sonataflow-infra",
                     "title": "The namespace Schema",
                     "examples": [
                         "sonataflow-infra"

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -63,7 +63,7 @@ postgres:
   database: sonataflow # existing database instance used by data index and job service
 
 orchestrator:
-  namespace: "" # Namespace where sonataflow's workflows run. The value is captured when running the configure_environment.sh script and stored as an annotation in the `orchestrator` namespace. User can override the value by populating this field. Defaults to `sonataflow-infra` if none is provided either via annotation or this field being empty.
+  namespace: "sonataflow-infra" # Namespace where sonataflow's workflows run. The value is captured when running the setup.sh script and stored as a label in the selected namespace. User can override the value by populating this field. Defaults to `sonataflow-infra`.
   sonataPlatform:
     resources:
       requests:
@@ -78,4 +78,4 @@ tekton:
 
 argocd:
   enabled: false # whether to install the ArgoCD plugin and create the orchestrator AppProject
-  namespace: "" # Defines the namespace where the orchestrator's instance of ArgoCD is deployed. The value is captured when running setup.sh script and stored as an annotation in the `orchestrator` namespace. User can override the value by populating this field. Defaults to `orchestrator-gitops` if none is provided either via annotation or this field being empty.
+  namespace: "" # Defines the namespace where the orchestrator's instance of ArgoCD is deployed. The value is captured when running setup.sh script and stored as a label in the selected namespace. User can override the value by populating this field. Defaults to `orchestrator-gitops` in the setup.sh script.


### PR DESCRIPTION
Adds `sonataflow-infra` as the default namespace in the `values.yaml` since we have a hardcoded dependency on the sonataflow services that need to be deployed in `sonataflow-infra`.

@masayag PTAL.