### PR TITLE
FLT-1292: Upgrade failure without gitops

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.27
+version: 0.2.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -114,9 +114,11 @@
 {{- end -}}
 
 {{- define "get-argocd-namespace" -}}
-    {{- if (not (hasKey . "argoCDNamespace" ) ) -}}
-        {{- $argoCDNamespace := include "get-namespace-with-label" (list .Values.argocd.namespace "rhdh.redhat.com/argocd-namespace")  }}
-        {{- $_ := set . "argoCDNamespace" $argoCDNamespace }}
+    {{- if .Values.argocd.enabled }}
+        {{- if (not (hasKey . "argoCDNamespace" ) ) -}}
+            {{- $argoCDNamespace := include "get-namespace-with-label" (list .Values.argocd.namespace "rhdh.redhat.com/argocd-namespace")  }}
+            {{- $_ := set . "argoCDNamespace" $argoCDNamespace }}
+        {{- end -}}
+        {{- .argoCDNamespace -}}
     {{- end -}}
-    {{- .argoCDNamespace -}}
 {{- end -}}s


### PR DESCRIPTION
Adds an additional check for the gitops namespace lookup function to see if argocd is enabled to perform the lookup, otherwise it returns an empty value.

@masayag PTAL.