### PR TITLE
[FLPATH-1297] Change setup.sh to allow non argocd deployments

### DIFF
--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -82,7 +82,6 @@ data:
       auth:
         keys:
           - secret: {{ printf "${%s}" .Values.rhdhOperator.secretRef.backstage.backendSecret }}
-
       baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.namespace }}.{{ include "cluster.domain" . }}
       csp:
         script-src: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-
-
-function exportWorkflowNamespace {
+function captureWorkflowNamespace {
   default="sonataflow-infra"
   if [ "$use_default" == true ]; then
     workflow_namespace="$default"
@@ -17,12 +15,16 @@ function exportWorkflowNamespace {
   WORKFLOW_NAMESPACE=$workflow_namespace
 }
 
-function exportK8sURL {
+function captureK8sURL {
   url="$(oc whoami --show-server)"
   K8S_CLUSTER_URL=$url
 }
 
-function exportK8sToken {
+function generateBackendSecret {
+  BACKEND_SECRET=$(mktemp -u XXXXXXXXXXXXXXXXXXXXXXX)
+}
+
+function generateK8sToken {
   sa_namespace="orchestrator"
   sa_name="orchestrator"
   if [ "$use_default" == false ]; then
@@ -57,7 +59,7 @@ function exportK8sToken {
   K8S_CLUSTER_TOKEN=$token
 }
 
-function exportGitToken {
+function captureGitToken {
    if [ -z "$GITHUB_TOKEN" ]; then
     read -s -p "Enter GitHub access token: " value
     echo ""
@@ -67,7 +69,7 @@ function exportGitToken {
   fi
 }
 
-function exportArgoCDNamespace {
+function captureArgoCDNamespace {
   default="orchestrator-gitops"
   if [ "$use_default" == true ]; then
     argocd_namespace="$default"
@@ -83,38 +85,39 @@ function exportArgoCDNamespace {
   ARGOCD_NAMESPACE=$argocd_namespace
 }
 
-function exportArgoCDURL {
+function captureArgoCDURL {
   argocd_instances=$(oc get argocd -n "$argocd_namespace" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
   if [ -z "$argocd_instances" ]; then
-      echo "No ArgoCD instances found in namespace $argocd_namespace."
-      exit 1
-  fi
-
-  if [ "$use_default" == true ]; then
-        selected_instance=$(echo "$argocd_instances" | awk 'NR==1')
-        echo "Select an ArgoCD instance: $selected_instance"
+      echo "No ArgoCD instances found in namespace $argocd_namespace. Continuing without ArgoCD support"
   else
-    echo "Select an ArgoCD instance:"
-    select instance in $argocd_instances; do
-        if [ -n "$instance" ]; then
-            selected_instance="$instance"
-            break
-        else
-            echo "Invalid selection. Please choose a valid option."
-        fi
-    done
+    if [ "$use_default" == true ]; then
+          selected_instance=$(echo "$argocd_instances" | awk 'NR==1')
+          echo "Select an ArgoCD instance: $selected_instance"
+    else
+      echo "Select an ArgoCD instance:"
+      select instance in $argocd_instances; do
+          if [ -n "$instance" ]; then
+              selected_instance="$instance"
+              break
+          else
+              echo "Invalid selection. Please choose a valid option."
+          fi
+      done
+    fi
+    argocd_route=$(oc get route -n $argocd_namespace -l app.kubernetes.io/managed-by=$selected_instance -ojsonpath='{.items[0].status.ingress[0].host}')
+    echo "Found Route at $argocd_route"
+    ARGOCD_URL=https://$argocd_route
   fi
 
-  argocd_route=$(oc get route -n $argocd_namespace -l app.kubernetes.io/managed-by=$selected_instance -ojsonpath='{.items[0].status.ingress[0].host}')
-  echo "Found Route at $argocd_route"
-  ARGOCD_URL=https://$argocd_route
 }
 
-function exportArgoCDCreds {
-  admin_password=$(oc get secret -n $argocd_namespace ${selected_instance}-cluster -ojsonpath='{.data.admin\.password}' | base64 -d)
-  ARGOCD_USERNAME=admin
-  ARGOCD_PASSWORD=$admin_password
+function captureArgoCDCreds {
+  if [ -n "$selected_instance" ]; then
+    admin_password=$(oc get secret -n $argocd_namespace ${selected_instance}-cluster -ojsonpath='{.data.admin\.password}' | base64 -d)
+    ARGOCD_USERNAME=admin
+    ARGOCD_PASSWORD=$admin_password
+  fi
 }
 
 function checkPrerequisite {
@@ -124,19 +127,34 @@ function checkPrerequisite {
   fi
 }
 
-
 function createBackstageSecret {
   if [[ $(oc get secret backstage-backend-auth-secret -n rhdh-operator) ]]; then
     oc delete secret backstage-backend-auth-secret -n rhdh-operator
   fi
-  oc create secret generic backstage-backend-auth-secret -n rhdh-operator \
-  --from-literal=BACKEND_SECRET=$BACKEND_SECRET \
-  --from-literal=K8S_CLUSTER_URL=$K8S_CLUSTER_URL \
-  --from-literal=K8S_CLUSTER_TOKEN=$K8S_CLUSTER_TOKEN \
-  --from-literal=ARGOCD_USERNAME=$ARGOCD_USERNAME \
-  --from-literal=ARGOCD_URL=$ARGOCD_URL \
-  --from-literal=ARGOCD_PASSWORD=$ARGOCD_PASSWORD \
-  --from-literal=GITHUB_TOKEN=$GITHUB_TOKEN
+  declare -A secretKeys
+  if [ -n "$K8S_CLUSTER_URL" ]; then
+    secretKeys[K8S_CLUSTER_URL]=$K8S_CLUSTER_URL
+  fi
+  if [ -n "$K8S_CLUSTER_TOKEN" ]; then
+    secretKeys[K8S_CLUSTER_TOKEN]=$K8S_CLUSTER_TOKEN
+  fi
+  if [ -n "$ARGOCD_USERNAME" ]; then
+    secretKeys[ARGOCD_USERNAME]=$ARGOCD_USERNAME
+  fi
+  if [ -n "$ARGOCD_URL" ]; then
+    secretKeys[ARGOCD_URL]=$ARGOCD_URL
+  fi
+  if [ -n "$ARGOCD_PASSWORD" ]; then
+    secretKeys[ARGOCD_PASSWORD]=$ARGOCD_PASSWORD
+  fi
+  if [ -n "$GITHUB_TOKEN" ]; then
+    secretKeys[GITHUB_TOKEN]=$GITHUB_TOKEN
+  fi
+  cmd="oc create secret generic backstage-backend-auth-secret -n rhdh-operator --from-literal=BACKEND_SECRET=$BACKEND_SECRET"
+  for key in "${!secretKeys[@]}"; do
+    cmd="${cmd} --from-literal=${key}=${secretKeys[$key]}"
+  done
+  eval $cmd
 }
 
 function labelNamespaces {
@@ -146,8 +164,12 @@ function labelNamespaces {
   for a in $(oc get namespace -l rhdh.redhat.com/argocd-namespace -oname); do
     oc label $a rhdh.redhat.com/argocd-namespace- ;
   done
-  oc label namespace $WORKFLOW_NAMESPACE rhdh.redhat.com/workflow-namespace=
-  oc label namespace $ARGOCD_NAMESPACE rhdh.redhat.com/argocd-namespace=
+  if [ -n "$WORKFLOW_NAMESPACE" ]; then
+    oc label namespace $WORKFLOW_NAMESPACE rhdh.redhat.com/workflow-namespace=
+  fi
+  if [[ -n "$ARGOCD_NAMESPACE" && -n "$ARGOCD_PASSWORD" && -n "$ARGOCD_URL" && -n "$ARGOCD_USERNAME" ]]; then
+    oc label namespace $ARGOCD_NAMESPACE rhdh.redhat.com/argocd-namespace=
+  fi
 }
 
 # Function to display usage instructions
@@ -176,8 +198,6 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-
-
 function main {
 
   # Check if using default values or not
@@ -186,27 +206,16 @@ function main {
   else
       echo "Not using default values."
   fi
-  # Variables for the backstage secret
-  local K8S_CLUSTER_URL
-  local K8S_CLUSTER_TOKEN
-  local GITHUB_TOKEN
-  local ARGOCD_URL
-  local ARGOCD_USERNAME
-  local ARGOCD_PASSWORD
-
-
-  # Variables for the orchestrator configmap
-  local WORKFLOW_NAMESPACE
-  local ARGOCD_NAMESPACE
 
   checkPrerequisite
-  exportWorkflowNamespace
-  exportK8sURL
-  exportK8sToken
-  exportGitToken
-  exportArgoCDNamespace
-  exportArgoCDURL
-  exportArgoCDCreds
+  generateBackendSecret
+  captureWorkflowNamespace
+  captureK8sURL
+  generateK8sToken
+  captureGitToken
+  captureArgoCDNamespace
+  captureArgoCDURL
+  captureArgoCDCreds
   createBackstageSecret
   labelNamespaces
   echo "Setup completed successfully!"


### PR DESCRIPTION
Changes the `hack/setup.sh` so that it now will succeed even if no argocd is found in the cluster. This change allows to run the script to generate the backstage secret for non-GitOps environments and removes the necessity in the installation process to specify a different path for non-GitOps environments.

Additionally, the secret created will contain only those keys that have been populated, thus avoiding secrets with keys with empty values.

Links to https://github.com/parodos-dev/orchestrator-helm-chart/pull/175
@batzionb @masayag @pkliczewski PTAL.