### PR TITLE
Redirect all output to /dev/null when checking for existing secret in setup.sh

### DIFF
--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -128,7 +128,7 @@ function checkPrerequisite {
 }
 
 function createBackstageSecret {
-  if [[ $(oc get secret backstage-backend-auth-secret -n rhdh-operator) ]]; then
+  if 2>/dev/null 1>&2 oc get secret backstage-backend-auth-secret -n rhdh-operator; then
     oc delete secret backstage-backend-auth-secret -n rhdh-operator
   fi
   declare -A secretKeys


### PR DESCRIPTION
Redirect all output to `/dev/null` when checking if the `backstage-backend-auth-secret` secret exists in the `rhdh-operator` namespace to avoid printing the error message `Error from server (NotFound): secrets "backstage-backend-auth-secret" not found` in the stdout when the secret does not exist.

Before:
```
$> ./hack/setup.sh
Not using default values.
...
...
Found Route at argocd-server-orchestrator-gitops.apps.stress.parodos.dev
Error from server (NotFound): secrets "backstage-backend-auth-secret" not found
secret/backstage-backend-auth-secret created
...
...
Setup completed successfully!
```

After:
```
$> ./hack/setup.sh
Not using default values.
...
Found Route at argocd-server-orchestrator-gitops.apps.stress.parodos.dev
secret/backstage-backend-auth-secret created
...
..
Setup completed successfully!
```
@masayag @chadcrum PTAL.