### PR TITLE
Update README.md for cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,13 @@ release "orchestrator" uninstalled
 ```
 
 Note that the CRDs created during the installation process will remain in the cluster.
-To clean the rest of the resources, run:
+
+Before cleaning the rest of the resources, if you have workflows installed, you will need to remove them from the cluster first:
+```console
+helm delete <workflow>
+```
+
+Then, to clean the rest of the resources, run:
 
 ```console
 oc get crd -o name | grep -e sonataflow -e rhdh -e knative | xargs oc delete

--- a/README.md
+++ b/README.md
@@ -249,17 +249,14 @@ release "orchestrator" uninstalled
 
 Note that the CRDs created during the installation process will remain in the cluster.
 
-Before cleaning the rest of the resources, if you have workflows installed, you will need to remove them from the cluster first:
-```console
-helm delete <workflow>
-```
+**Note that if you installed additional Knative resources (service, ingress, ...) you shall delete them before trying to remove the Knative related CRDs. Otherwise the deletion will get stuck**
 
-Then, to clean the rest of the resources, run:
-
+To clean the rest of the resources, run:
 ```console
 oc get crd -o name | grep -e sonataflow -e rhdh -e knative | xargs oc delete
 oc delete namespace orchestrator sonataflow-infra rhdh-operator
 ```
+
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Follow [Workflows Installation](https://www.parodos.dev/serverless-workflows-con
 
 ## Cleanup
 
+**\/!\\ Before removing the orchestrator, make sure you first removed installed workflows. Otherwise the deletion may hung in termination state**
+
 To remove the installation from the cluster, run:
 
 ```console
@@ -249,12 +251,15 @@ release "orchestrator" uninstalled
 
 Note that the CRDs created during the installation process will remain in the cluster.
 
-**Note that if you installed additional Knative resources (service, ingress, ...) you shall delete them before trying to remove the Knative related CRDs. Otherwise the deletion will get stuck**
-
 To clean the rest of the resources, run:
 ```console
-oc get crd -o name | grep -e sonataflow -e rhdh -e knative | xargs oc delete
+oc get crd -o name | grep -e sonataflow -e rhdh | xargs oc delete
 oc delete namespace orchestrator sonataflow-infra rhdh-operator
+```
+
+If you want to remove *knative* related resources, you may also run:
+```console
+oc get crd -o name | grep -e knative | xargs oc delete
 ```
 
 


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-1320

If M2K workflow is installed `oc get crd -o name | grep -e sonataflow -e rhdh -e knative | xargs oc delete` will delete `services.serving.knative.dev` and `ingresses.networking.internal.knative.dev`. But then `m2k-save-transformation-func`  `ingresses.networking.internal.knative.dev` is still there and blocks the deletion of the CRD:
```
$ oc get ingresses.networking.internal.knative.dev -A
NAMESPACE          NAME                           READY   REASON
sonataflow-infra   m2k-save-transformation-func   True    
```

If a workflow is installing Knative resources, when cleanuping the orchestrator helm chart, those Knative resource will likely generate an issue, like for M2K

This PR explicitly state to remove all additional resources before deleting the CRD and the namespace.
