### PR TITLE
Remove complex assessment gpt

### DIFF
--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -325,8 +325,6 @@ data:
           target: https://github.com/parodos-dev/workflow-software-templates/blob/main/entities/workflow-resources.yaml
         - type: url
           target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/basic-workflow/template.yaml
-        - type: url
-          target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/complex-assessment-workflow/template.yaml
 {{- end }}
 {{- $unmanagedNamespaceExists := include "unmanaged-resource-exists" (list "rhdh.redhat.com/v1alpha1" "Backstage" .Values.rhdhOperator.subscription.namespace "backstage" .Release.Name .Capabilities.APIVersions ) }}
 {{- if eq $unmanagedNamespaceExists "false" }}


### PR DESCRIPTION
This PR removes the complex workflow gpt for the ongoing release due to issues with CI/CD  integration in the Sonata workflow build process.
The CI/CD integration issue will be addressed in a subsequent pull request (via FLPATH-1318) to reinstate the complex workflow gpt functionality once the issue is resolved.