### PR TITLE
Capture GitHub client {Id,Secret} in hack/setup.sh

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.32
+version: 0.2.33
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -69,6 +69,26 @@ function captureGitToken {
   fi
 }
 
+function captureGitClientId {
+   if [ -z "$GITHUB_CLIENT_ID" ]; then
+    read -s -p "Enter GitHub client ID (empty for disabling it): " value
+    echo ""
+    GITHUB_CLIENT_ID=$value
+  else
+    echo "GitHub client ID already set."
+  fi
+}
+
+function captureGitClientSecret {
+   if [ -z "$GITHUB_CLIENT_SECRET" ]; then
+    read -s -p "Enter GitHub client secret (empty for disabling it): " value
+    echo ""
+    GITHUB_CLIENT_SECRET=$value
+  else
+    echo "GitHub client secret already set."
+  fi
+}
+
 function captureArgoCDNamespace {
   default="orchestrator-gitops"
   if [ "$use_default" == true ]; then
@@ -150,6 +170,12 @@ function createBackstageSecret {
   if [ -n "$GITHUB_TOKEN" ]; then
     secretKeys[GITHUB_TOKEN]=$GITHUB_TOKEN
   fi
+  if [ -n "$GITHUB_CLIENT_ID" ]; then
+    secretKeys[GITHUB_CLIENT_ID]=$GITHUB_CLIENT_ID
+  fi
+  if [ -n "$GITHUB_CLIENT_SECRET" ]; then
+    secretKeys[GITHUB_CLIENT_SECRET]=$GITHUB_CLIENT_SECRET
+  fi
   cmd="oc create secret generic backstage-backend-auth-secret -n rhdh-operator --from-literal=BACKEND_SECRET=$BACKEND_SECRET"
   for key in "${!secretKeys[@]}"; do
     cmd="${cmd} --from-literal=${key}=${secretKeys[$key]}"
@@ -213,6 +239,8 @@ function main {
   captureK8sURL
   generateK8sToken
   captureGitToken
+  captureGitClientId
+  captureGitClientSecret
   captureArgoCDNamespace
   captureArgoCDURL
   captureArgoCDCreds


### PR DESCRIPTION
Captures the GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET in the `hack/setup.sh` script so that it is captured in the secret and consumed by the helm chart.

@masayag PTAL.