### PR TITLE
Add steps for setting GitOps operators

### DIFF
--- a/gitops/resources/argocd-example.yaml
+++ b/gitops/resources/argocd-example.yaml
@@ -22,10 +22,10 @@ spec:
         memory: 128Mi
     enabled: false
   rbac:
-    defaultPolicy: ''
+    defaultPolicy: ""
     policy: |
       g, system:cluster-admins, role:admin
-    scopes: '[groups]'
+    scopes: "[groups]"
   redis:
     resources:
       limits:
@@ -63,11 +63,3 @@ spec:
           memory: 128Mi
       openShiftOAuth: true
     provider: dex
-  resourceExclusions: |
-    - apiGroups:
-      - tekton.dev
-      clusters:
-      - '*'
-      kinds:
-      - TaskRun
-      - PipelineRun


### PR DESCRIPTION
Add an alternative for using the Janus-IDP demo charts for installing the OpenShift Pipelines and the OpenShift GitOps operators.

Fixes #103 

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED