### PR TITLE
Add a network policy to allow backstage-sonata traffic

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc12
+version: 1.2.0-rc13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/NOTES.txt
+++ b/charts/orchestrator/templates/NOTES.txt
@@ -124,6 +124,9 @@ Run the following commands to wait until the services are ready:
   oc wait -n {{ .Values.rhdhOperator.subscription.namespace }} backstage backstage --for=condition=Deployed=True
   oc wait -n {{ .Values.rhdhOperator.subscription.namespace }} deploy/backstage-backstage --for=condition=Available {{ $timeout }}
 {{- end }}
+{{- if eq $sonataFlowPlatformInstalled $yes }}
+  oc get networkpolicy -n {{ $workflowNamespace }}
+{{- end }}
 
 In case of a CR deployment failure, check the logs of the pods created by the corresponding job to deploy the failed CRs instance. The jobs are always
 deleted after the deployment of the chart is completed.

--- a/charts/orchestrator/templates/network-policies.yaml
+++ b/charts/orchestrator/templates/network-policies.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.sonataFlowOperator.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-rhdh-to-sonataflow-and-workflows
+  # Sonataflow and Workflows are using the same namespace.
+  namespace: "{{- include "get-workflow-namespace" . }}"
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            # Allow RHDH namespace to communicate with workflows and sonataflow services
+            kubernetes.io/metadata.name: {{ .Values.rhdhOperator.subscription.namespace }}
+      - namespaceSelector:
+          matchLabels:
+            # Allow any other namespace the has workflows deployed because this is where
+            # this namespace contains the sonataflow services
+            rhdh.redhat.com/workflow-namespace: ""
+{{- end }}


### PR DESCRIPTION

    Add a network policy to allow backstage-sonata traffic
    
    When installing Sonataflow operator, also set those network policies based on
    namespaces labels:
    1. A policy on the workflow namespace[1] that allow ingress from sonata
       namespace and RHDH namespace
    2. A policy on the Sonata namespace where the cluster services are
       running that allow ingress from workflows namespaces[2] and RHDH
       namespace
    
    [1] workflow namespace is set as part of of hack/setup.sh script
    [2] workflows namespaces are any namespaces with label key rhdh.redhat.com/workflow-namespace

Signed-off-by: Roy Golan <rgolan@redhat.com>
