### PR TITLE
Change SonataFlow subscription's name to logic-operator-rhel8

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.34
+version: 0.2.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -12,7 +12,7 @@ serverlessOperator:
     namespace: openshift-serverless # namespace where the operator should be deployed
     channel: stable # channel of an operator package to subscribe to
     installPlanApproval: Automatic # whether the update should be installed automatically
-    name: serverless-operator # name of the operator package
+    name: logic-operator-rhel8 # name of the operator package
 
 rhdhOperator:
   enabled: true # whether the operator should be deployed by the chart


### PR DESCRIPTION
Fix a problem with the SonataFlow operator where it fails to install because the subscription name has changed and fails to find the CSV.

@masayag PTAL.

@chadcrum FYI.
