### PR TITLE
Revert "Change SonataFlow subscription's name to logic-operator-rhel8"

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.35
+version: 0.2.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -12,7 +12,7 @@ serverlessOperator:
     namespace: openshift-serverless # namespace where the operator should be deployed
     channel: stable # channel of an operator package to subscribe to
     installPlanApproval: Automatic # whether the update should be installed automatically
-    name: logic-operator-rhel8 # name of the operator package
+    name: serverless-operator # name of the operator package
 
 rhdhOperator:
   enabled: true # whether the operator should be deployed by the chart


### PR DESCRIPTION
This reverts commit 7a73955a3430ee5bbc1e69c1e922b6cf994d5891.

@masayag Is it ok for you to use revert for a change that caused a bug? Otherwise I'll raise a PR to manually revert it and increase the chart version. Note that this is so far the last commit that is being reverted, so decrementing the chart version number by one is not an issue in this case.