### PR TITLE
[FLPATH-1418] Create SA token instead of capturing it from the secret

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.40
+version: 0.2.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -69,9 +69,7 @@ function generateK8sToken {
 
   oc adm policy add-cluster-role-to-user cluster-admin -z $sa_name -n $sa_namespace
   echo "Added cluster-admin role to '$sa_name' in '$sa_namespace'."
-  token_secret=$(oc get secret -o name -n $sa_namespace | grep ${sa_name}-token)
-  token=$(oc get -n $sa_namespace ${token_secret} -o jsonpath="{.data.token}" | sed 's/"//g' | base64 -d)
-  K8S_CLUSTER_TOKEN=$token
+  K8S_CLUSTER_TOKEN=$(oc create token ${sa_name} -n $sa_namespace)
 }
 
 function captureGitToken {


### PR DESCRIPTION
Creates a token for the SA instead of retrieving it from the generated secret, as it seems like the secret is no longer created by default for k8s v1.28+ (OCP 4.15+)

@masayag PTAL
@y-first @chadcrum FYI