### PR TITLE
Fix reference mismatch for orchestrator.sonata{flow|}Platform

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc1
+version: 1.2.0-rc2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -68,10 +68,10 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `postgres.authSecret.passwordKey` | name of key in existing secret to use for PostgreSQL credentials. | `"postgres-password"` |
 | `postgres.database` | existing database instance used by data index and job service | `"sonataflow"` |
 | `orchestrator.namespace` | Namespace where sonataflow's workflows run. The value is captured when running the setup.sh script and stored as a label in the selected namespace. User can override the value by populating this field. Defaults to `sonataflow-infra`. | `"sonataflow-infra"` |
-| `orchestrator.sonataPlatform.resources.requests.memory` |  | `"64Mi"` |
-| `orchestrator.sonataPlatform.resources.requests.cpu` |  | `"250m"` |
-| `orchestrator.sonataPlatform.resources.limits.memory` |  | `"1Gi"` |
-| `orchestrator.sonataPlatform.resources.limits.cpu` |  | `"500m"` |
+| `orchestrator.sonataflowPlatform.resources.requests.memory` |  | `"64Mi"` |
+| `orchestrator.sonataflowPlatform.resources.requests.cpu` |  | `"250m"` |
+| `orchestrator.sonataflowPlatform.resources.limits.memory` |  | `"1Gi"` |
+| `orchestrator.sonataflowPlatform.resources.limits.cpu` |  | `"500m"` |
 | `tekton.enabled` | whether to create the Tekton pipeline resources | `false` |
 | `argocd.enabled` | whether to install the ArgoCD plugin and create the orchestrator AppProject | `false` |
 | `argocd.namespace` | Defines the namespace where the orchestrator's instance of ArgoCD is deployed. The value is captured when running setup.sh script and stored as a label in the selected namespace. User can override the value by populating this field. Defaults to `orchestrator-gitops` in the setup.sh script. | `""` |

--- a/charts/orchestrator/templates/sonataflows.yaml
+++ b/charts/orchestrator/templates/sonataflows.yaml
@@ -27,11 +27,11 @@ spec:
     template:
       resources:
         requests:
-          memory: {{ .Values.orchestrator.sonataPlatform.resources.requests.memory }}
-          cpu: {{ .Values.orchestrator.sonataPlatform.resources.requests.cpu }}
+          memory: {{ .Values.orchestrator.sonataflowPlatform.resources.requests.memory }}
+          cpu: {{ .Values.orchestrator.sonataflowPlatform.resources.requests.cpu }}
         limits:
-          memory: {{ .Values.orchestrator.sonataPlatform.resources.limits.memory }}
-          cpu: {{ .Values.orchestrator.sonataPlatform.resources.limits.cpu }}
+          memory: {{ .Values.orchestrator.sonataflowPlatform.resources.limits.memory }}
+          cpu: {{ .Values.orchestrator.sonataflowPlatform.resources.limits.cpu }}
   services:
     dataIndex:
       enabled: true


### PR DESCRIPTION
The key references used in the `values-rc.yaml` that point to the beaker images are not consistent with the values in the `values.yaml` for the `orchestrator.sonataPlatform` sub-structure. This PR aligns the name to match the `values-rc.yaml` so that it is consistent across files.
https://github.com/parodos-dev/orchestrator-helm-chart/blob/82ada07ad87b855b736a1383fe7f12790fb1c7e0/charts/orchestrator/values.yaml#L82-L86

versus

https://github.com/parodos-dev/orchestrator-helm-chart/blob/82ada07ad87b855b736a1383fe7f12790fb1c7e0/charts/orchestrator/values-rc.yaml#L37-L41

@masayag PTAL. 

@chadcrum @y-first  FYI.
