### PR TITLE
Ensure sonataflow custom service images are used only when provided

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc3
+version: 1.2.0-rc4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/sonataflows.yaml
+++ b/charts/orchestrator/templates/sonataflows.yaml
@@ -44,7 +44,7 @@ spec:
           serviceRef:
             name: {{ .Values.postgres.serviceName }}
             namespace: {{ .Values.postgres.serviceNamespace }}
-      {{- if not .Values.orchestrator.sonataflowPlatform.dataIndexImage }}
+      {{- if .Values.orchestrator.sonataflowPlatform.dataIndexImage }}
       podTemplate:
         container:
           image: {{ .Values.orchestrator.sonataflowPlatform.dataIndexImage }}
@@ -60,7 +60,7 @@ spec:
           serviceRef:
             name: {{ .Values.postgres.serviceName }}
             namespace: {{ .Values.postgres.serviceNamespace }}
-      {{- if not .Values.orchestrator.sonataflowPlatform.jobServiceImage }}
+      {{- if .Values.orchestrator.sonataflowPlatform.jobServiceImage }}
       podTemplate:
         container:
           image: {{ .Values.orchestrator.sonataflowPlatform.jobServiceImage }}


### PR DESCRIPTION
Tested locally with success:
* When image is provided, the SonataFlowPlatform CR contains the podTemplate field with the image.
* When image is not provided, the sonataFlowPlatform CR does not contain a podTemplate field.

@masayag PTAL

@chadcrum @y-first FYI.