### PR TITLE
Add support for configuring the notifications email server

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc11
+version: 1.2.0-rc12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhOperator.isReleaseCandidate` | Indicates RC builds should be used by the chart to install RHDH | `false` |
 | `rhdhOperator.enabled` | whether the operator should be deployed by the chart | `true` |
 | `rhdhOperator.enableGuestProvider` | whether to enable guest provider | `false` |
-| `rhdhOperator.secretRef.name` | name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD and GitHub servers. | `"backstage-backend-auth-secret"` |
+| `rhdhOperator.secretRef.name` | name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD, GitHub servers and SMTP mail server. | `"backstage-backend-auth-secret"` |
 | `rhdhOperator.secretRef.backstage.backendSecret` | Key in the secret with name defined in the 'name' field that contains the value of the Backstage backend secret. Defaults to 'BACKEND_SECRET'. It's required. | `"BACKEND_SECRET"` |
 | `rhdhOperator.secretRef.github.token` | Key in the secret with name defined in the 'name' field that contains the value of the authentication token as expected by GitHub. Required for importing resource to the catalog, launching software templates and more. Defaults to 'GITHUB_TOKEN', empty for not available. | `"GITHUB_TOKEN"` |
 | `rhdhOperator.secretRef.github.clientId` | Key in the secret with name defined in the 'name' field that contains the value of the client ID that you generated on GitHub, for GitHub authentication (requires GitHub App). Defaults to 'GITHUB_CLIENT_ID', empty for not available. | `"GITHUB_CLIENT_ID"` |
@@ -39,6 +39,9 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhOperator.secretRef.argocd.url` | Key in the secret with name defined in the 'name' field that contains the value of the URL of the ArgoCD API server. Defaults to 'ARGOCD_URL', empty for not available. | `"ARGOCD_URL"` |
 | `rhdhOperator.secretRef.argocd.username` | Key in the secret with name defined in the 'name' field that contains the value of the username to login to ArgoCD. Defaults to 'ARGOCD_USERNAME', empty for not available. | `"ARGOCD_USERNAME"` |
 | `rhdhOperator.secretRef.argocd.password` | Key in the secret with name  defined in the 'name' field that contains the value of the password to authenticate to ArgoCD. Defaults to 'ARGOCD_PASSWORD', empty for not available. | `"ARGOCD_PASSWORD"` |
+| `rhdhOperator.secretRef.notifications_email.hostname` | Key in the secret with name defined in the 'name' field that contains the value of the hostname of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_HOSTNAME', empty for not available. | `"NOTIFICATIONS_EMAIL_HOSTNAME"` |
+| `rhdhOperator.secretRef.notifications_email.username` | Key in the secret with name defined in the 'name' field that contains the value of the username of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_USERNAME', empty for not available. | `"NOTIFICATIONS_EMAIL_USERNAME"` |
+| `rhdhOperator.secretRef.notifications_email.password` | Key in the secret with name defined in the 'name' field that contains the value of the password of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_PASSWORD', empty for not available. | `"NOTIFICATIONS_EMAIL_PASSWORD"` |
 | `rhdhOperator.subscription.namespace` | namespace where the operator should be deployed | `"rhdh-operator"` |
 | `rhdhOperator.subscription.channel` | channel of an operator package to subscribe to | `"fast-1.2"` |
 | `rhdhOperator.subscription.installPlanApproval` | whether the update should be installed automatically | `"Automatic"` |
@@ -59,8 +62,12 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhPlugins.signals.integrity` |  | `"sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg=="` |
 | `rhdhPlugins.signals_backend.package` |  | `"plugin-signals-backend-dynamic@0.1.3-rc.0-0"` |
 | `rhdhPlugins.signals_backend.integrity` |  | `"sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="` |
+| `rhdhPlugins.notifications_email.enabled` | whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. | `false` |
 | `rhdhPlugins.notifications_email.package` |  | `"plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"` |
 | `rhdhPlugins.notifications_email.integrity` |  | `"sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="` |
+| `rhdhPlugins.notifications_email.port` | SMTP server port | `587` |
+| `rhdhPlugins.notifications_email.sender` | the email sender address | `""` |
+| `rhdhPlugins.notifications_email.reply_to` | reply-to address | `""` |
 | `postgres.serviceName` | The name of the Postgres DB service to be used by platform services. Cannot be empty. | `"sonataflow-psql-postgresql"` |
 | `postgres.serviceNamespace` | The namespace of the Postgres DB service to be used by platform services. | `"sonataflow-infra"` |
 | `postgres.authSecret.name` | name of existing secret to use for PostgreSQL credentials. | `"sonataflow-psql-postgresql"` |

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -39,9 +39,9 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhOperator.secretRef.argocd.url` | Key in the secret with name defined in the 'name' field that contains the value of the URL of the ArgoCD API server. Defaults to 'ARGOCD_URL', empty for not available. | `"ARGOCD_URL"` |
 | `rhdhOperator.secretRef.argocd.username` | Key in the secret with name defined in the 'name' field that contains the value of the username to login to ArgoCD. Defaults to 'ARGOCD_USERNAME', empty for not available. | `"ARGOCD_USERNAME"` |
 | `rhdhOperator.secretRef.argocd.password` | Key in the secret with name  defined in the 'name' field that contains the value of the password to authenticate to ArgoCD. Defaults to 'ARGOCD_PASSWORD', empty for not available. | `"ARGOCD_PASSWORD"` |
-| `rhdhOperator.secretRef.notifications_email.hostname` | Key in the secret with name defined in the 'name' field that contains the value of the hostname of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_HOSTNAME', empty for not available. | `"NOTIFICATIONS_EMAIL_HOSTNAME"` |
-| `rhdhOperator.secretRef.notifications_email.username` | Key in the secret with name defined in the 'name' field that contains the value of the username of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_USERNAME', empty for not available. | `"NOTIFICATIONS_EMAIL_USERNAME"` |
-| `rhdhOperator.secretRef.notifications_email.password` | Key in the secret with name defined in the 'name' field that contains the value of the password of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_PASSWORD', empty for not available. | `"NOTIFICATIONS_EMAIL_PASSWORD"` |
+| `rhdhOperator.secretRef.notificationsEmail.hostname` | Key in the secret with name defined in the 'name' field that contains the value of the hostname of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_HOSTNAME', empty for not available. | `"NOTIFICATIONS_EMAIL_HOSTNAME"` |
+| `rhdhOperator.secretRef.notificationsEmail.username` | Key in the secret with name defined in the 'name' field that contains the value of the username of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_USERNAME', empty for not available. | `"NOTIFICATIONS_EMAIL_USERNAME"` |
+| `rhdhOperator.secretRef.notificationsEmail.password` | Key in the secret with name defined in the 'name' field that contains the value of the password of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_PASSWORD', empty for not available. | `"NOTIFICATIONS_EMAIL_PASSWORD"` |
 | `rhdhOperator.subscription.namespace` | namespace where the operator should be deployed | `"rhdh-operator"` |
 | `rhdhOperator.subscription.channel` | channel of an operator package to subscribe to | `"fast-1.2"` |
 | `rhdhOperator.subscription.installPlanApproval` | whether the update should be installed automatically | `"Automatic"` |
@@ -62,12 +62,12 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhPlugins.signals.integrity` |  | `"sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg=="` |
 | `rhdhPlugins.signals_backend.package` |  | `"plugin-signals-backend-dynamic@0.1.3-rc.0-0"` |
 | `rhdhPlugins.signals_backend.integrity` |  | `"sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="` |
-| `rhdhPlugins.notifications_email.enabled` | whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. | `false` |
+| `rhdhPlugins.notifications_email.enabled` | whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts | `false` |
 | `rhdhPlugins.notifications_email.package` |  | `"plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"` |
 | `rhdhPlugins.notifications_email.integrity` |  | `"sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="` |
 | `rhdhPlugins.notifications_email.port` | SMTP server port | `587` |
 | `rhdhPlugins.notifications_email.sender` | the email sender address | `""` |
-| `rhdhPlugins.notifications_email.reply_to` | reply-to address | `""` |
+| `rhdhPlugins.notifications_email.replyTo` | reply-to address | `""` |
 | `postgres.serviceName` | The name of the Postgres DB service to be used by platform services. Cannot be empty. | `"sonataflow-psql-postgresql"` |
 | `postgres.serviceNamespace` | The namespace of the Postgres DB service to be used by platform services. | `"sonataflow-infra"` |
 | `postgres.authSecret.name` | name of existing secret to use for PostgreSQL credentials. | `"sonataflow-psql-postgresql"` |

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -52,22 +52,22 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhPlugins.scope` |  | `"@redhat"` |
 | `rhdhPlugins.orchestrator.package` |  | `"backstage-plugin-orchestrator@1.1.0-rc.0-0"` |
 | `rhdhPlugins.orchestrator.integrity` |  | `"sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ=="` |
-| `rhdhPlugins.orchestrator_backend.package` |  | `"backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0"` |
-| `rhdhPlugins.orchestrator_backend.integrity` |  | `"sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw=="` |
+| `rhdhPlugins.orchestratorBackend.package` |  | `"backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0"` |
+| `rhdhPlugins.orchestratorBackend.integrity` |  | `"sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw=="` |
 | `rhdhPlugins.notifications.package` |  | `"plugin-notifications-dynamic@0.2.0-rc.0-0"` |
 | `rhdhPlugins.notifications.integrity` |  | `"sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g=="` |
-| `rhdhPlugins.notifications_backend.package` |  | `"plugin-notifications-backend-dynamic@0.2.0-rc.0-0"` |
-| `rhdhPlugins.notifications_backend.integrity` |  | `"sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ=="` |
+| `rhdhPlugins.notificationsBackend.package` |  | `"plugin-notifications-backend-dynamic@0.2.0-rc.0-0"` |
+| `rhdhPlugins.notificationsBackend.integrity` |  | `"sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ=="` |
 | `rhdhPlugins.signals.package` |  | `"plugin-signals-dynamic@0.0.5-rc.0-0"` |
 | `rhdhPlugins.signals.integrity` |  | `"sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg=="` |
-| `rhdhPlugins.signals_backend.package` |  | `"plugin-signals-backend-dynamic@0.1.3-rc.0-0"` |
-| `rhdhPlugins.signals_backend.integrity` |  | `"sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="` |
-| `rhdhPlugins.notifications_email.enabled` | whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts | `false` |
-| `rhdhPlugins.notifications_email.package` |  | `"plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"` |
-| `rhdhPlugins.notifications_email.integrity` |  | `"sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="` |
-| `rhdhPlugins.notifications_email.port` | SMTP server port | `587` |
-| `rhdhPlugins.notifications_email.sender` | the email sender address | `""` |
-| `rhdhPlugins.notifications_email.replyTo` | reply-to address | `""` |
+| `rhdhPlugins.signalsBackend.package` |  | `"plugin-signals-backend-dynamic@0.1.3-rc.0-0"` |
+| `rhdhPlugins.signalsBackend.integrity` |  | `"sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="` |
+| `rhdhPlugins.notificationsEmail.enabled` | whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts | `false` |
+| `rhdhPlugins.notificationsEmail.package` |  | `"plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"` |
+| `rhdhPlugins.notificationsEmail.integrity` |  | `"sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="` |
+| `rhdhPlugins.notificationsEmail.port` | SMTP server port | `587` |
+| `rhdhPlugins.notificationsEmail.sender` | the email sender address | `""` |
+| `rhdhPlugins.notificationsEmail.replyTo` | reply-to address | `""` |
 | `postgres.serviceName` | The name of the Postgres DB service to be used by platform services. Cannot be empty. | `"sonataflow-psql-postgresql"` |
 | `postgres.serviceNamespace` | The namespace of the Postgres DB service to be used by platform services. | `"sonataflow-infra"` |
 | `postgres.authSecret.name` | name of existing secret to use for PostgreSQL credentials. | `"sonataflow-psql-postgresql"` |

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -285,8 +285,8 @@ data:
         integrity: {{ .Values.rhdhPlugins.signals_backend.integrity }}
   {{- if and .Values.rhdhPlugins.notifications_email.enabled
         ( and
-            (and (.Values.rhdhOperator.secretRef.notifications_email.hostname) (dig "data" .Values.rhdhOperator.secretRef.notifications_email.hostname "" $secret ) )
-            (and (.Values.rhdhOperator.secretRef.notifications_email.username) (.Values.rhdhOperator.secretRef.notifications_email.password) )
+            (and (.Values.rhdhOperator.secretRef.notificationsEmail.hostname) (dig "data" .Values.rhdhOperator.secretRef.notificationsEmail.hostname "" $secret ) )
+            (and (.Values.rhdhOperator.secretRef.notificationsEmail.username) (.Values.rhdhOperator.secretRef.notificationsEmail.password) )
         )
   }}
       - disabled: false
@@ -298,15 +298,13 @@ data:
                email:
                  transportConfig:
                    transport: smtp
-                   hostname: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notifications_email.hostname }}
+                   hostname: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.hostname }}
                    port: {{ .Values.rhdhPlugins.notifications_email.port }}
                    secure: false
-                   username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notifications_email.username }}
-                   password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notifications_email.password }}
+                   username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.username }}
+                   password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.password }}
                  sender: {{ .Values.rhdhPlugins.notifications_email.sender }}
-                 replyTo: {{ .Values.rhdhPlugins.notifications_email.reply_to }}
-                 broadcastConfig:
-                   receiver: users
+                 replyTo: {{ .Values.rhdhPlugins.notifications_email.replyTo }}
                  concurrencyLimit: 10
                  cache:
                    ttl:

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -283,6 +283,12 @@ data:
       - disabled: false
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signals_backend.package }}"
         integrity: {{ .Values.rhdhPlugins.signals_backend.integrity }}
+  {{- if and .Values.rhdhPlugins.notifications_email.enabled
+        ( and
+            (and (.Values.rhdhOperator.secretRef.notifications_email.hostname) (dig "data" .Values.rhdhOperator.secretRef.notifications_email.hostname "" $secret ) )
+            (and (.Values.rhdhOperator.secretRef.notifications_email.username) (.Values.rhdhOperator.secretRef.notifications_email.password) )
+        )
+  }}
       - disabled: false
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notifications_email.package }}"
         integrity: {{ .Values.rhdhPlugins.notifications_email.integrity }}
@@ -292,19 +298,20 @@ data:
                email:
                  transportConfig:
                    transport: smtp
-                   hostname: my-smtp-server
-                   port: 587
+                   hostname: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notifications_email.hostname }}
+                   port: {{ .Values.rhdhPlugins.notifications_email.port }}
                    secure: false
-                   username: my-username
-                   password: my-password
-                 sender: sender@mycompany.com
-                 replyTo: no-reply@mycompany.com
+                   username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notifications_email.username }}
+                   password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notifications_email.password }}
+                 sender: {{ .Values.rhdhPlugins.notifications_email.sender }}
+                 replyTo: {{ .Values.rhdhPlugins.notifications_email.reply_to }}
                  broadcastConfig:
                    receiver: users
                  concurrencyLimit: 10
                  cache:
                    ttl:
-                     days: 1        
+                     days: 1
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -230,8 +230,8 @@ data:
               type: config
   {{- end }}
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.orchestrator_backend.package }}"
-        integrity: {{ .Values.rhdhPlugins.orchestrator_backend.integrity }}
+        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.orchestratorBackend.package }}"
+        integrity: {{ .Values.rhdhPlugins.orchestratorBackend.integrity }}
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -278,20 +278,20 @@ data:
             frontend:
               redhat.plugin-signals: {}
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notifications_backend.package }}"
-        integrity: {{ .Values.rhdhPlugins.notifications_backend.integrity }}
+        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notificationsBackend.package }}"
+        integrity: {{ .Values.rhdhPlugins.notificationsBackend.integrity }}
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signals_backend.package }}"
-        integrity: {{ .Values.rhdhPlugins.signals_backend.integrity }}
-  {{- if and .Values.rhdhPlugins.notifications_email.enabled
+        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signalsBackend.package }}"
+        integrity: {{ .Values.rhdhPlugins.signalsBackend.integrity }}
+  {{- if and .Values.rhdhPlugins.notificationsEmail.enabled
         ( and
             (and (.Values.rhdhOperator.secretRef.notificationsEmail.hostname) (dig "data" .Values.rhdhOperator.secretRef.notificationsEmail.hostname "" $secret ) )
             (and (.Values.rhdhOperator.secretRef.notificationsEmail.username) (.Values.rhdhOperator.secretRef.notificationsEmail.password) )
         )
   }}
       - disabled: false
-        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notifications_email.package }}"
-        integrity: {{ .Values.rhdhPlugins.notifications_email.integrity }}
+        package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notificationsEmail.package }}"
+        integrity: {{ .Values.rhdhPlugins.notificationsEmail.integrity }}
         pluginConfig:
           notifications:
              processors:
@@ -299,12 +299,12 @@ data:
                  transportConfig:
                    transport: smtp
                    hostname: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.hostname }}
-                   port: {{ .Values.rhdhPlugins.notifications_email.port }}
+                   port: {{ .Values.rhdhPlugins.notificationsEmail.port }}
                    secure: false
                    username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.username }}
                    password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.password }}
-                 sender: {{ .Values.rhdhPlugins.notifications_email.sender }}
-                 replyTo: {{ .Values.rhdhPlugins.notifications_email.replyTo }}
+                 sender: {{ .Values.rhdhPlugins.notificationsEmail.sender }}
+                 replyTo: {{ .Values.rhdhPlugins.notificationsEmail.replyTo }}
                  concurrencyLimit: 10
                  cache:
                    ttl:

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -594,12 +594,12 @@
                 "npmRegistry",
                 "scope",
                 "orchestrator",
-                "orchestrator_backend",
+                "orchestratorBackend",
                 "notifications",
-                "notifications_backend",
+                "notificationsBackend",
                 "signals",
-                "signals_backend",
-                "notifications_email"
+                "signalsBackend",
+                "notificationsEmail"
             ],
             "properties": {
                 "npmRegistry": {
@@ -649,10 +649,10 @@
                         "integrity": "sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ=="
                     }]
                 },
-                "orchestrator_backend": {
+                "orchestratorBackend": {
                     "type": "object",
                     "default": {},
-                    "title": "The orchestrator_backend Schema",
+                    "title": "The orchestratorBackend Schema",
                     "required": [
                         "package",
                         "integrity"
@@ -711,10 +711,10 @@
                         "integrity": "sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g=="
                     }]
                 },
-                "notifications_backend": {
+                "notificationsBackend": {
                     "type": "object",
                     "default": {},
-                    "title": "The notifications_backend Schema",
+                    "title": "The notificationsBackend Schema",
                     "required": [
                         "package",
                         "integrity"
@@ -773,10 +773,10 @@
                         "integrity": "sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg=="
                     }]
                 },
-                "signals_backend": {
+                "signalsBackend": {
                     "type": "object",
                     "default": {},
-                    "title": "The signals_backend Schema",
+                    "title": "The signalsBackend Schema",
                     "required": [
                         "package",
                         "integrity"
@@ -804,10 +804,10 @@
                         "integrity": "sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="
                     }]
                 },
-                "notifications_email": {
+                "notificationsEmail": {
                     "type": "object",
                     "default": {},
-                    "title": "The notifications_email Schema",
+                    "title": "The notificationsEmail Schema",
                     "required": [
                         "enabled",
                         "package",
@@ -883,7 +883,7 @@
                     "package": "backstage-plugin-orchestrator@1.1.0-rc.0-0",
                     "integrity": "sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ=="
                 },
-                "orchestrator_backend": {
+                "orchestratorBackend": {
                     "package": "backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0",
                     "integrity": "sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw=="
                 },
@@ -891,7 +891,7 @@
                     "package": "plugin-notifications-dynamic@0.2.0-rc.0-0",
                     "integrity": "sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g=="
                 },
-                "notifications_backend": {
+                "notificationsBackend": {
                     "package": "plugin-notifications-backend-dynamic@0.2.0-rc.0-0",
                     "integrity": "sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ=="
                 },
@@ -899,11 +899,11 @@
                     "package": "plugin-signals-dynamic@0.0.5-rc.0-0",
                     "integrity": "sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg=="
                 },
-                "signals_backend": {
+                "signalsBackend": {
                     "package": "plugin-signals-backend-dynamic@0.1.3-rc.0-0",
                     "integrity": "sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="
                 },
-                "notifications_email": {
+                "notificationsEmail": {
                     "enabled": false,
                     "package": "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0",
                     "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
@@ -1261,7 +1261,7 @@
                 "package": "backstage-plugin-orchestrator@1.1.0-rc.0-0",
                 "integrity": "sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ=="
             },
-            "orchestrator_backend": {
+            "orchestratorBackend": {
                 "package": "backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0",
                 "integrity": "sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw=="
             },
@@ -1269,7 +1269,7 @@
                 "package": "plugin-notifications-dynamic@0.2.0-rc.0-0",
                 "integrity": "sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g=="
             },
-            "notifications_backend": {
+            "notificationsBackend": {
                 "package": "plugin-notifications-backend-dynamic@0.2.0-rc.0-0",
                 "integrity": "sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ=="
             },
@@ -1277,11 +1277,11 @@
                 "package": "plugin-signals-dynamic@0.0.5-rc.0-0",
                 "integrity": "sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg=="
             },
-            "signals_backend": {
+            "signalsBackend": {
                 "package": "plugin-signals-backend-dynamic@0.1.3-rc.0-0",
                 "integrity": "sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="
             },
-            "notifications_email": {
+            "notificationsEmail": {
                 "enabled": false,
                 "package": "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0",
                 "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -261,7 +261,8 @@
                         "backstage",
                         "github",
                         "k8s",
-                        "argocd"
+                        "argocd",
+                        "notifications_email"
                     ],
                     "properties": {
                         "name": {
@@ -405,6 +406,47 @@
                                 "username": "ARGOCD_USERNAME",
                                 "password": "ARGOCD_PASSWORD"
                             }]
+                        },
+                        "notifications_email": {
+                            "type": "object",
+                            "default": {},
+                            "title": "The notifications_email Schema",
+                            "required": [
+                                "hostname",
+                                "username",
+                                "password"
+                            ],
+                            "properties": {
+                                "hostname": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The hostname Schema",
+                                    "examples": [
+                                        "NOTIFICATIONS_EMAIL_HOSTNAME"
+                                    ]
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The username Schema",
+                                    "examples": [
+                                        "NOTIFICATIONS_EMAIL_USERNAME"
+                                    ]
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "The password Schema",
+                                    "examples": [
+                                        "NOTIFICATIONS_EMAIL_PASSWORD"
+                                    ]
+                                }
+                            },
+                            "examples": [{
+                                "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
+                                "username": "NOTIFICATIONS_EMAIL_USERNAME",
+                                "password": "NOTIFICATIONS_EMAIL_PASSWORD"
+                            }]
                         }
                     },
                     "examples": [{
@@ -425,6 +467,11 @@
                             "url": "ARGOCD_URL",
                             "username": "ARGOCD_USERNAME",
                             "password": "ARGOCD_PASSWORD"
+                        },
+                        "notifications_email": {
+                            "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
+                            "username": "NOTIFICATIONS_EMAIL_USERNAME",
+                            "password": "NOTIFICATIONS_EMAIL_PASSWORD"
                         }
                     }]
                 },
@@ -522,6 +569,11 @@
                         "url": "ARGOCD_URL",
                         "username": "ARGOCD_USERNAME",
                         "password": "ARGOCD_PASSWORD"
+                    },
+                    "notifications_email": {
+                        "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
+                        "username": "NOTIFICATIONS_EMAIL_USERNAME",
+                        "password": "NOTIFICATIONS_EMAIL_PASSWORD"
                     }
                 },
                 "subscription": {
@@ -757,10 +809,22 @@
                     "default": {},
                     "title": "The notifications_email Schema",
                     "required": [
+                        "enabled",
                         "package",
-                        "integrity"
+                        "integrity",
+                        "port",
+                        "sender",
+                        "reply_to"
                     ],
                     "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "The enabled Schema",
+                            "examples": [
+                                false
+                            ]
+                        },
                         "package": {
                             "type": "string",
                             "default": "",
@@ -776,11 +840,39 @@
                             "examples": [
                                 "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="
                             ]
+                        },
+                        "port": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "The port Schema",
+                            "examples": [
+                                587
+                            ]
+                        },
+                        "sender": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The sender Schema",
+                            "examples": [
+                                ""
+                            ]
+                        },
+                        "reply_to": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The reply_to Schema",
+                            "examples": [
+                                ""
+                            ]
                         }
                     },
                     "examples": [{
+                        "enabled": false,
                         "package": "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0",
-                        "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="
+                        "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
+                        "port": 587,
+                        "sender": "",
+                        "reply_to": ""
                     }]
                 }
             },
@@ -812,8 +904,12 @@
                     "integrity": "sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="
                 },
                 "notifications_email": {
+                    "enabled": false,
                     "package": "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0",
-                    "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="
+                    "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
+                    "port": 587,
+                    "sender": "",
+                    "reply_to": ""
                 }
             }]
         },
@@ -1142,6 +1238,11 @@
                     "url": "ARGOCD_URL",
                     "username": "ARGOCD_USERNAME",
                     "password": "ARGOCD_PASSWORD"
+                },
+                "notifications_email": {
+                    "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
+                    "username": "NOTIFICATIONS_EMAIL_USERNAME",
+                    "password": "NOTIFICATIONS_EMAIL_PASSWORD"
                 }
             },
             "subscription": {
@@ -1181,8 +1282,12 @@
                 "integrity": "sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg=="
             },
             "notifications_email": {
+                "enabled": false,
                 "package": "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0",
-                "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA=="
+                "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
+                "port": 587,
+                "sender": "",
+                "reply_to": ""
             }
         },
         "postgres": {

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -262,7 +262,7 @@
                         "github",
                         "k8s",
                         "argocd",
-                        "notifications_email"
+                        "notificationsEmail"
                     ],
                     "properties": {
                         "name": {
@@ -407,10 +407,10 @@
                                 "password": "ARGOCD_PASSWORD"
                             }]
                         },
-                        "notifications_email": {
+                        "notificationsEmail": {
                             "type": "object",
                             "default": {},
-                            "title": "The notifications_email Schema",
+                            "title": "The notificationsEmail Schema",
                             "required": [
                                 "hostname",
                                 "username",
@@ -468,7 +468,7 @@
                             "username": "ARGOCD_USERNAME",
                             "password": "ARGOCD_PASSWORD"
                         },
-                        "notifications_email": {
+                        "notificationsEmail": {
                             "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
                             "username": "NOTIFICATIONS_EMAIL_USERNAME",
                             "password": "NOTIFICATIONS_EMAIL_PASSWORD"
@@ -570,7 +570,7 @@
                         "username": "ARGOCD_USERNAME",
                         "password": "ARGOCD_PASSWORD"
                     },
-                    "notifications_email": {
+                    "notificationsEmail": {
                         "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
                         "username": "NOTIFICATIONS_EMAIL_USERNAME",
                         "password": "NOTIFICATIONS_EMAIL_PASSWORD"
@@ -814,7 +814,7 @@
                         "integrity",
                         "port",
                         "sender",
-                        "reply_to"
+                        "replyTo"
                     ],
                     "properties": {
                         "enabled": {
@@ -857,10 +857,10 @@
                                 ""
                             ]
                         },
-                        "reply_to": {
+                        "replyTo": {
                             "type": "string",
                             "default": "",
-                            "title": "The reply_to Schema",
+                            "title": "The replyTo Schema",
                             "examples": [
                                 ""
                             ]
@@ -872,7 +872,7 @@
                         "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
                         "port": 587,
                         "sender": "",
-                        "reply_to": ""
+                        "replyTo": ""
                     }]
                 }
             },
@@ -909,7 +909,7 @@
                     "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
                     "port": 587,
                     "sender": "",
-                    "reply_to": ""
+                    "replyTo": ""
                 }
             }]
         },
@@ -1239,7 +1239,7 @@
                     "username": "ARGOCD_USERNAME",
                     "password": "ARGOCD_PASSWORD"
                 },
-                "notifications_email": {
+                "notificationsEmail": {
                     "hostname": "NOTIFICATIONS_EMAIL_HOSTNAME",
                     "username": "NOTIFICATIONS_EMAIL_USERNAME",
                     "password": "NOTIFICATIONS_EMAIL_PASSWORD"
@@ -1287,7 +1287,7 @@
                 "integrity": "sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==",
                 "port": 587,
                 "sender": "",
-                "reply_to": ""
+                "replyTo": ""
             }
         },
         "postgres": {

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -23,7 +23,7 @@ rhdhOperator:
   enabled: true # whether the operator should be deployed by the chart
   enableGuestProvider: false # whether to enable guest provider
   secretRef:
-    name: backstage-backend-auth-secret # name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD and GitHub servers.
+    name: backstage-backend-auth-secret # name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD, GitHub servers and SMTP mail server.
     backstage:
       backendSecret: BACKEND_SECRET # Key in the secret with name defined in the 'name' field that contains the value of the Backstage backend secret. Defaults to 'BACKEND_SECRET'. It's required.
     github: #GitHub specific configuration fields that are injected to the backstage instance to allow the plugin to communicate with GitHub.
@@ -37,6 +37,11 @@ rhdhOperator:
       url: ARGOCD_URL # Key in the secret with name defined in the 'name' field that contains the value of the URL of the ArgoCD API server. Defaults to 'ARGOCD_URL', empty for not available.
       username: ARGOCD_USERNAME # Key in the secret with name defined in the 'name' field that contains the value of the username to login to ArgoCD. Defaults to 'ARGOCD_USERNAME', empty for not available.
       password: ARGOCD_PASSWORD # Key in the secret with name  defined in the 'name' field that contains the value of the password to authenticate to ArgoCD. Defaults to 'ARGOCD_PASSWORD', empty for not available.
+    notifications_email:
+      hostname: NOTIFICATIONS_EMAIL_HOSTNAME # Key in the secret with name defined in the 'name' field that contains the value of the hostname of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_HOSTNAME', empty for not available.
+      username: NOTIFICATIONS_EMAIL_USERNAME # Key in the secret with name defined in the 'name' field that contains the value of the username of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_USERNAME', empty for not available.
+      password: NOTIFICATIONS_EMAIL_PASSWORD # Key in the secret with name defined in the 'name' field that contains the value of the password of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_PASSWORD', empty for not available.
+
   subscription:
     namespace: rhdh-operator # namespace where the operator should be deployed
     channel: fast-1.2 # channel of an operator package to subscribe to
@@ -67,8 +72,12 @@ rhdhPlugins: # RHDH plugins required for the Orchestrator
     package: "plugin-signals-backend-dynamic@0.1.3-rc.0-0"
     integrity: sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg==
   notifications_email:
+    enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret.
     package: "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"
     integrity: sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==
+    port: 587 # SMTP server port
+    sender: "" # the email sender address
+    reply_to: "" # reply-to address
 
 postgres:
   serviceName: "sonataflow-psql-postgresql" # The name of the Postgres DB service to be used by platform services. Cannot be empty.

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -56,22 +56,22 @@ rhdhPlugins: # RHDH plugins required for the Orchestrator
   orchestrator:
     package: "backstage-plugin-orchestrator@1.1.0-rc.0-0"
     integrity: sha512-uxkNFS/4nkVM6FRq0Uvnznvxcm/3MNdh11R6sRsbmKCP4KF4N9T2GF4lgfD7J+p7EuGMD4UFnjKjaR77v0NGaQ==
-  orchestrator_backend:
+  orchestratorBackend:
     package: "backstage-plugin-orchestrator-backend-dynamic@1.1.0-rc.0-0"
     integrity: sha512-NIIGpwH/uJaMknTdORdnqsHfPeI/OrAl2biqELal1e9tK2r6PrVWfIWr9XoH5AfOjtQjbeAe7joiLwhM+uyVAw==
   notifications:
     package: "plugin-notifications-dynamic@0.2.0-rc.0-0"
     integrity: sha512-wmISWN02G4OiBF7y8Jpl5KCbDfhzl70s+r0h2tdVh1IIwYmojH5pqXFQAhDd3FTlqYc8yqDG8gEAQ8v66qbU1g==
-  notifications_backend:
+  notificationsBackend:
     package: "plugin-notifications-backend-dynamic@0.2.0-rc.0-0"
     integrity: sha512-CHTNYVGWPxT94viabzCqxKIkDxflium9vkgh9Emu+3SuJSEsrZ6G+U1UZgpQ4gO03oOeiTm3xsoTg/AfKGf7CQ==
   signals:
     package: "plugin-signals-dynamic@0.0.5-rc.0-0"
     integrity: sha512-5Iwp9gF6VPiMLJ5NUw5s5Z17AuJ5XYS97wghNTfcmah/OFxTmgZHWxvhcRoXDRQvyj4nc/gOZes74kp6kZ9XDg==
-  signals_backend:
+  signalsBackend:
     package: "plugin-signals-backend-dynamic@0.1.3-rc.0-0"
     integrity: sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg==
-  notifications_email:
+  notificationsEmail:
     enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
     package: "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"
     integrity: sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -37,7 +37,7 @@ rhdhOperator:
       url: ARGOCD_URL # Key in the secret with name defined in the 'name' field that contains the value of the URL of the ArgoCD API server. Defaults to 'ARGOCD_URL', empty for not available.
       username: ARGOCD_USERNAME # Key in the secret with name defined in the 'name' field that contains the value of the username to login to ArgoCD. Defaults to 'ARGOCD_USERNAME', empty for not available.
       password: ARGOCD_PASSWORD # Key in the secret with name  defined in the 'name' field that contains the value of the password to authenticate to ArgoCD. Defaults to 'ARGOCD_PASSWORD', empty for not available.
-    notifications_email:
+    notificationsEmail:
       hostname: NOTIFICATIONS_EMAIL_HOSTNAME # Key in the secret with name defined in the 'name' field that contains the value of the hostname of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_HOSTNAME', empty for not available.
       username: NOTIFICATIONS_EMAIL_USERNAME # Key in the secret with name defined in the 'name' field that contains the value of the username of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_USERNAME', empty for not available.
       password: NOTIFICATIONS_EMAIL_PASSWORD # Key in the secret with name defined in the 'name' field that contains the value of the password of the SMTP server for the notifications plugin. Defaults to 'NOTIFICATIONS_EMAIL_PASSWORD', empty for not available.
@@ -72,12 +72,12 @@ rhdhPlugins: # RHDH plugins required for the Orchestrator
     package: "plugin-signals-backend-dynamic@0.1.3-rc.0-0"
     integrity: sha512-LlkM2Mf2QTndsS6eBzyXDhJmRTHLpAku3hhlvWhtQChSLTFCtNGRTIQA5WHG7NqLH0QqBz+UcEjX7Vca82QKKg==
   notifications_email:
-    enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret.
+    enabled: false # whether to install the notifications email plugin. requires setting of hostname and credentials in backstage secret to enable. See value backstage-backend-auth-secret. See plugin configuration at https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts
     package: "plugin-notifications-backend-module-email-dynamic@0.0.0-rc.0-0"
     integrity: sha512-TikxFBxBHKJYZy8go+Mw+7yjfSJILgXjr4K0C0+tnKyMOn+OqIX6K8c1fq7IdXto3fftQ+mmCrBqJem25JjVnA==
     port: 587 # SMTP server port
     sender: "" # the email sender address
-    reply_to: "" # reply-to address
+    replyTo: "" # reply-to address
 
 postgres:
   serviceName: "sonataflow-psql-postgresql" # The name of the Postgres DB service to be used by platform services. Cannot be empty.

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -165,6 +165,50 @@ function captureArgoCDCreds {
   fi
 }
 
+function captureNotificationsEmailHostname {
+   if [ -z "$NOTIFICATIONS_EMAIL_HOSTNAME" ]; then
+    read -p "Enter the SMTP server hostname for notification emails (empty for disabling it): " value
+    echo ""
+    NOTIFICATIONS_EMAIL_HOSTNAME=$value
+  else
+    echo "SMTP server hostname for notification emails already set."
+  fi
+}
+
+function captureNotificationsEmailUsername {
+   if [ -z "$NOTIFICATIONS_EMAIL_USERNAME" ]; then
+    read -p "Enter the SMTP server username for notification emails (empty for disabling it): " value
+    echo ""
+    NOTIFICATIONS_EMAIL_USERNAME=$value
+  else
+    echo "SMTP server username for notification emails already set."
+  fi
+}
+
+function captureNotificationsEmailPassword {
+   if [ -z "$NOTIFICATIONS_EMAIL_PASSWORD" ]; then
+    read -s -p "Enter the SMTP server password for notification emails (empty for disabling it): " value
+    echo ""
+    NOTIFICATIONS_EMAIL_PASSWORD=$value
+  else
+    echo "SMTP server password for notification emails already set."
+  fi
+}
+
+function setupNotificationsEmailConfig {
+  if $use_default; then
+    SETUP_NOTIFICATIONS_EMAIL=true
+  else
+    echo "Setup a notifications email plugin?:"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes ) SETUP_NOTIFICATIONS_EMAIL=true; break;;
+            No ) SETUP_NOTIFICATIONS_EMAIL=false; break;;
+        esac
+    done
+  fi
+}
+
 function checkPrerequisite {
   if ! command -v oc &> /dev/null; then
     echo "oc is required for this script to run. Exiting."
@@ -200,6 +244,15 @@ function createBackstageSecret {
   fi
   if [ -n "$GITHUB_CLIENT_SECRET" ]; then
     secretKeys[GITHUB_CLIENT_SECRET]=$GITHUB_CLIENT_SECRET
+  fi
+  if [ -n "$NOTIFICATIONS_EMAIL_HOSTNAME" ]; then
+    secretKeys[NOTIFICATIONS_EMAIL_HOSTNAME]=$NOTIFICATIONS_EMAIL_HOSTNAME
+  fi
+  if [ -n "$NOTIFICATIONS_EMAIL_USERNAME" ]; then
+    secretKeys[NOTIFICATIONS_EMAIL_USERNAME]=$NOTIFICATIONS_EMAIL_USERNAME
+  fi
+  if [ -n "$NOTIFICATIONS_EMAIL_PASSWORD" ]; then
+    secretKeys[NOTIFICATIONS_EMAIL_PASSWORD]=$NOTIFICATIONS_EMAIL_PASSWORD
   fi
   cmd="oc create secret generic backstage-backend-auth-secret -n rhdh-operator --from-literal=BACKEND_SECRET=$BACKEND_SECRET"
   for key in "${!secretKeys[@]}"; do
@@ -275,6 +328,12 @@ function main {
     captureGitToken
     captureGitClientId
     captureGitClientSecret
+    setupNotificationsEmailConfig
+    if $SETUP_NOTIFICATIONS_EMAIL; then
+      captureNotificationsEmailHostname
+      captureNotificationsEmailUsername
+      captureNotificationsEmailPassword
+    fi
     createBackstageSecret
   fi
   echo "Setup completed successfully!"

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -245,13 +245,13 @@ function createBackstageSecret {
   if [ -n "$GITHUB_CLIENT_SECRET" ]; then
     secretKeys[GITHUB_CLIENT_SECRET]=$GITHUB_CLIENT_SECRET
   fi
-  if [ -n "$NOTIFICATIONS_EMAIL_HOSTNAME" ]; then
+  if [ -n "$NOTIFICATIONS_EMAIL_HOSTNAME" ] && [ "$SETUP_NOTIFICATIONS_EMAIL" = true ]; then
     secretKeys[NOTIFICATIONS_EMAIL_HOSTNAME]=$NOTIFICATIONS_EMAIL_HOSTNAME
   fi
-  if [ -n "$NOTIFICATIONS_EMAIL_USERNAME" ]; then
+  if [ -n "$NOTIFICATIONS_EMAIL_USERNAME" ] && [ "$SETUP_NOTIFICATIONS_EMAIL" = true ]; then
     secretKeys[NOTIFICATIONS_EMAIL_USERNAME]=$NOTIFICATIONS_EMAIL_USERNAME
   fi
-  if [ -n "$NOTIFICATIONS_EMAIL_PASSWORD" ]; then
+  if [ -n "$NOTIFICATIONS_EMAIL_PASSWORD" ] && [ "$SETUP_NOTIFICATIONS_EMAIL" = true ]; then
     secretKeys[NOTIFICATIONS_EMAIL_PASSWORD]=$NOTIFICATIONS_EMAIL_PASSWORD
   fi
   cmd="oc create secret generic backstage-backend-auth-secret -n rhdh-operator --from-literal=BACKEND_SECRET=$BACKEND_SECRET"


### PR DESCRIPTION
The notifications email plugin enabled the user to fan-out emails if the recipients has an email address associated with the user definition.
To enable this feature, there is a need to configure the notifications email plugin.
    
The values.yaml exposes the values for some of the plugin attributed, and the sensitive information (hostname, username and password) are expected to be provided when executing the setup.sh script.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED