### PR TITLE
k8s: Set and use backstage secret

### DIFF
--- a/charts/orchestrator-k8s/Chart.yaml
+++ b/charts/orchestrator-k8s/Chart.yaml
@@ -3,13 +3,13 @@ name: orchestrator-k8s
 description: |
   Helm chart to deploy the Orchestrator solution suite on Kubernetes, including Janus IDP backstage, SonataFlow Operator, Knative Eventing and Knative Serving.
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.0.1"
 
 dependencies:
   - name: backstage
-    repository: https://janus-idp.github.io/helm-backstage
-    version: "2.11.4"
+    repository: https://redhat-developer.github.io/rhdh-chart 
+    version: "2.16.7"
   - name: postgresql-persistent
     repository: https://sclorg.github.io/helm-charts
     version: "0.0.3"

--- a/charts/orchestrator-k8s/README.md
+++ b/charts/orchestrator-k8s/README.md
@@ -5,7 +5,7 @@ This chart will install the Orchestrator and all its dependencies on kubernetes.
 **THIS CHART IS NOT SUITED FOR PRODUCTION PURPOSES**, you should only use it for development or tests purposes
 
 The chart deploys:
-- Janus-IDP
+- RHDH-backstage https://github.com/redhat-developer/rhdh-chart
 - Serverless Workflows Operator (see sonata-serverless-operator.yaml)
 - knative serving
 - Knative eventing
@@ -19,18 +19,29 @@ helm repo add orchestrator https://parodos-dev.github.io/orchestrator-helm-chart
 helm install orchestrator orchestrator/orchestrator-k8s
 ```
 
+## Configuration
+All of the backstage app-config is derived from the values.yaml.
+
+### Secrets as env vars:
+To use secret as env vars, like the one used for the notification, see charts/Orchestrator-k8s/templates/secret.yaml
+Every key in that secret will be available in the app-config for resolution.
+
 
 ## Development
 ```console
 git clone https://github.com/parodos-dev.github.io/orchestrator-helm-chart
 cd orchestrator-helm-chart/charts/orchestrator-k8s
 
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add backstage https://backstage.github.io/charts
 helm repo add postgresql-persistent https://sclorg.github.io/helm-charts
-helm repo add backstage https://janus-idp.github.io/helm-backstage
+helm repo add redhat-developer https://redhat-developer.github.io/rhdh-chart
+helm install backstage redhat-developer/backstage
 helm repo add workflows https://parodos.dev/serverless-workflows-config
 
 helm dependencies build
-helm install orchestrator . -f values.yaml
+helm install orchestrator .
 ```
 
 
@@ -44,18 +55,16 @@ NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 NOTES:
-This chart will install Janus-IDP + Serverless Workflows.
+This chart will install RHDH-backstage(RHDH upstream) + Serverless Workflows.
 
-It is under development and meant for non-prod environment for now
-
-To get Jauns-IDP's route location:
+To get RHDH's route location:
     $ oc get route orchestrator-white-backstage -o jsonpath='https://{ .spec.host }{"\n"}'
 
 To get the serverless workflow operator status:
     $ oc get deploy -n sonataflow-operator-system 
 
-To get the serverless workflow status:
-    $ oc get sf starter 
+To get the serverless workflows status:
+    $ oc get sf
 
 ```
 

--- a/charts/orchestrator-k8s/templates/NOTES.txt
+++ b/charts/orchestrator-k8s/templates/NOTES.txt
@@ -1,19 +1,14 @@
-This chart will install Janus-IDP + Serverless Workflows.
+This chart will install RHDH + orchestrator plugin + Serverless Workflows.
 
 It is under development and meant for non-prod environment for now
 
-To get Jauns-IDP's route location:
+To get RHDH's route location:
     $ oc get route {{ .Release.Name }}-backstage -o jsonpath='https://{ .spec.host }{"\n"}'
 
 To get the serverless workflow operator status:
     $ oc get deploy -n sonataflow-operator-system 
 
-To get the serverless workflow status:
-    $ oc get sf {{ .Values.flowName }} -n {{ .Release.Namespace }}
+To get the serverless workflows status:
+    $ oc get sf 
 
-To get the devmode deployment status
-    $ oc get deploy devmode -n {{ .Release.Namespace }}
-
-Use Janus-IDP workflows plugins to manage your deployed workflows. Explore the various templates
-with type 'workflows' and run them. You should see a template with the name {{ .Values.flowName }}
-For more data click on the 'workflows...' side-panel entry.
+You should now have RHDH with the orchestrator plugin installed to manage your deployed workflows.

--- a/charts/orchestrator-k8s/templates/secret.yaml
+++ b/charts/orchestrator-k8s/templates/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-backend-auth-secret
+data:
+  ADMIN_CURL_TOKEN: ZTJldG9rZW4=

--- a/charts/orchestrator-k8s/values.yaml
+++ b/charts/orchestrator-k8s/values.yaml
@@ -147,6 +147,8 @@ backstage:
 
       image:
         tag: next
+      extraEnvVarsSecrets:
+        - backstage-backend-auth-secret
       appConfig:
         app:
           baseUrl: http://localhost:9090
@@ -159,6 +161,15 @@ backstage:
             - host: github.com
               token: "INSERT VALID TOKEN HERE"
         auth:
+          externalAccess:
+            - type: static
+              options:
+                token: ${ADMIN_CURL_TOKEN}
+                subject: admin-curl-access
+            - type: static
+              options:
+                token: ${ADMIN_CURL_TOKEN}
+                subject: notifications-access
           environment: development
           providers:
             github:


### PR DESCRIPTION
This is mainly needed for the notifications plugins but also useful for
any other secret we set in app-config using env vars as all of the
secret content is loaded as env using envFrom into the backstage
deployment.

Signed-off-by: Roy Golan <rgolan@redhat.com>
