### PR TITLE
orchestrator-k8s: various values.yaml fixes

### DIFF
--- a/charts/orchestrator-k8s/Chart.yaml
+++ b/charts/orchestrator-k8s/Chart.yaml
@@ -3,7 +3,7 @@ name: orchestrator-k8s
 description: |
   Helm chart to deploy the Orchestrator solution suite on Kubernetes, including Janus IDP backstage, SonataFlow Operator, Knative Eventing and Knative Serving.
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "0.0.1"
 
 dependencies:

--- a/charts/orchestrator-k8s/values.yaml
+++ b/charts/orchestrator-k8s/values.yaml
@@ -93,6 +93,16 @@ backstage:
         integrity: >-
           sha512-FVMmIHjAoRg+kzpEhkEjtCKgRanWHwaI9I2Jqj9/gObnF2WBIllzAPiGNxj6tkMFloLflSJc6kc9ZphttAGGcQ==
   upstream:
+    # TODO when setting this to false the secret is still referenced in the rhdh
+    # deployment, looks like rhdh-backstage chart doesn't support excluding
+    # the postrgres secret part.
+    postgresql:
+      #enabled: false
+      primary:
+        resources:
+          limits:
+            ephemeral-storage: 1Mi
+
     ingress:
       enabled: true  # Use Kubernetes Ingress instead of OpenShift Route
     backstage:
@@ -118,8 +128,8 @@ backstage:
         - name: dynamic-plugins
           configMap:
             defaultMode: 420
-            name: dynamic-plugins
-            optional: true
+            name: '{{ printf "%s-dynamic-plugins" .Release.Name }}'
+            optional: false
         # Optional volume that allows exposing the `.npmrc` file (through a `dynamic-plugins-npmrc` secret)
         # to be used when running `npm pack` during the dynamic plugins installation by the initContainer.
         - name: dynamic-plugins-npmrc
@@ -130,10 +140,13 @@ backstage:
         - name: npmcacache
           emptyDir: {}
       extraVolumeMounts:
-        - name: dynamic-plugins-root
-          mountPath: /opt/app-root/src/dynamic-plugins-root
         - name: backstage-locations
           mountPath: /opt/backstage/locations
+        - mountPath: /dynamic-plugins-root
+          name: dynamic-plugins-root
+        - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins
+          name: dynamic-plugins-npmrc
+
       resources:
         limits:
           memory: 2Gi


### PR DESCRIPTION
1. postgresql ephemeral storage value was too low and caused hitting the
   limit and restart of the pod.
2. Missing volume mounts, because the extraVolumeMounts is not really
   extra, but rather overrides that field
3. The dynamic plugins config map name changes to be prefixed with the
   release name

Signed-off-by: Roy Golan <rgolan@redhat.com>
