### PR TITLE
Update kn cli to fixed version that includes the kn-workflow plugin

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/tekton-tasks.yaml
+++ b/charts/orchestrator/templates/tekton-tasks.yaml
@@ -208,7 +208,7 @@ spec:
       workingDir: $(workspaces.workflow-source.path)/flat/$(params.workflowId)
       script: |
         microdnf install -y tar gzip
-        KN_CLI_URL="https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz"
+        KN_CLI_URL="https://mirror.openshift.com/pub/openshift-v4/clients/serverless/1.11.2/kn-linux-amd64.tar.gz"
         curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-linux-amd64 && mv kn-linux-amd64 kn
         ./kn workflow gen-manifest --namespace ""
 ---


### PR DESCRIPTION
The latest version of the `kn` cli excludes the kn-workflow plugin from it. Therefore we should rely on the latest version oc `kn` cli that included it, and matches the sonataflow operator version.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED