### PR TITLE
FLPATH-1525: minor clarifications + typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL
   - Validated APIs are `tekton.dev/v1beta1/Task` and `tekton.dev/v1/Pipeline`
   - Requires ArgoCD installed since the manifests are deployed in the same namespace as the ArgoCD instance.
 
-  Remember to enable enable [argocd](https://github.com/parodos-dev/orchestrator-helm-chart/blob/145a6cb647253faa1e8d50fcaac75988f5807724/charts/orchestrator/values.yaml#L80) and [tekton](https://github.com/parodos-dev/orchestrator-helm-chart/blob/145a6cb647253faa1e8d50fcaac75988f5807724/charts/orchestrator/values.yaml#L77) in the `values.yaml` or, alternatively, enabled them via helm's setting flag in the CLI when installing the chart. Example:
+  Remember to enable [argocd](https://github.com/parodos-dev/orchestrator-helm-chart/blob/145a6cb647253faa1e8d50fcaac75988f5807724/charts/orchestrator/values.yaml#L80) and [tekton](https://github.com/parodos-dev/orchestrator-helm-chart/blob/145a6cb647253faa1e8d50fcaac75988f5807724/charts/orchestrator/values.yaml#L77) in the `values.yaml` or, alternatively, enabled them via helm's setting flag in the CLI when installing the chart. Example:
 
   ```console
   helm upgrade -i ... --set argocd.enabled=true --set tekton.enabled=true

--- a/gitops/README.md
+++ b/gitops/README.md
@@ -98,6 +98,10 @@ There is a need to create a single K8s secret combined with the following secret
 Those two K8s secrets should be merged into a single secret named `docker-credentials` in `orchestrator-gitops` namespace in the cluster that runs the pipelines.
 You may use this [helper script](https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/hack/merge_secrets.sh) to merge the secrets or choose another method of downloading the credentials and merging them.
 
+Note: If using helper script, ensure to add merged secret to orchestrator-gitops namespace.
+```console
+oc apply -f <secret-name.yaml> -n orchestrator-gitops
+```
 ## Define the SSH credentials
 
 The pipeline uses SSH to push the deployment configuration to the `gitops` repository containing the `kustomize` deployment configuration.
@@ -128,7 +132,7 @@ ssh-keyscan github.com > ssh/known_hosts
 ```console
 echo "Host github.com
   HostName github.com
-  IdentityFile ~/.ssh/id_rsa" > ssh/config
+  IdentityFile ~/ssh/id_rsa" > ssh/config
 ```
 
 - Create the secret that the Pipeline uses to store the SSH credentials:

--- a/gitops/README.md
+++ b/gitops/README.md
@@ -132,7 +132,7 @@ ssh-keyscan github.com > ssh/known_hosts
 ```console
 echo "Host github.com
   HostName github.com
-  IdentityFile ~/ssh/id_rsa" > ssh/config
+  IdentityFile ~/.ssh/id_rsa" > ssh/config
 ```
 
 - Create the secret that the Pipeline uses to store the SSH credentials:


### PR DESCRIPTION
- Fixed typo in documentation (during argocd process)
- Added clarification for docker credentials secret creation.
- Fixed typo in ssh folder for ssh config file creation.