### PR TITLE
Use Dockerfile for 1.1.x

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/tekton-tasks.yaml
+++ b/charts/orchestrator/templates/tekton-tasks.yaml
@@ -188,7 +188,7 @@ spec:
           cp -r workflow/$(params.workflowId) flat/$(params.workflowId)
         fi
 
-        curl -L https://raw.githubusercontent.com/parodos-dev/serverless-workflows/main/pipeline/workflow-builder.Dockerfile -o flat/workflow-builder.Dockerfile
+        curl -L https://raw.githubusercontent.com/parodos-dev/serverless-workflows/v1.1.x/pipeline/workflow-builder.Dockerfile -o flat/workflow-builder.Dockerfile
 ---
 apiVersion: tekton.dev/v1
 kind: Task


### PR DESCRIPTION
Due to not using a dedicated branch for 1.1.x releases and pointing to the main branch instead, the pipeline for building a workflow was impacted by recent changes.

This PR pin the tekton task referred links to a fixated branch.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED