### PR TITLE
Use kn-workflow v1.33

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc13
+version: 1.2.0-rc15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/tekton-tasks.yaml
+++ b/charts/orchestrator/templates/tekton-tasks.yaml
@@ -215,9 +215,9 @@ spec:
       workingDir: $(workspaces.workflow-source.path)/flat/$(params.workflowId)
       script: |
         microdnf install -y tar gzip
-        KN_CLI_URL="https://mirror.openshift.com/pub/openshift-v4/clients/serverless/1.11.2/kn-linux-amd64.tar.gz"
-        curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-linux-amd64 && mv kn-linux-amd64 kn
-        ./kn workflow gen-manifest --namespace ""
+        KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.33.0/kn-workflow-linux-amd64.tar.gz"
+        curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-workflow-linux-amd64 && mv kn-workflow-linux-amd64 kn-workflow
+        ./kn-workflow gen-manifest --namespace ""
 ---
 apiVersion: tekton.dev/v1
 kind: Task


### PR DESCRIPTION
The tekton task created by the chart should use the kn-workflow version that matches the sonataflow operator.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED