### PR TITLE
Make notifications email username and password optional

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc15
+version: 1.2.0-rc16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -284,10 +284,7 @@ data:
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.signalsBackend.package }}"
         integrity: {{ .Values.rhdhPlugins.signalsBackend.integrity }}
   {{- if and .Values.rhdhPlugins.notificationsEmail.enabled
-        ( and
-            (and (.Values.rhdhOperator.secretRef.notificationsEmail.hostname) (dig "data" .Values.rhdhOperator.secretRef.notificationsEmail.hostname "" $secret ) )
-            (and (.Values.rhdhOperator.secretRef.notificationsEmail.username) (.Values.rhdhOperator.secretRef.notificationsEmail.password) )
-        )
+        ( and (.Values.rhdhOperator.secretRef.notificationsEmail.hostname) (dig "data" .Values.rhdhOperator.secretRef.notificationsEmail.hostname "" $secret ) )
   }}
       - disabled: false
         package: "{{ .Values.rhdhPlugins.scope }}/{{ .Values.rhdhPlugins.notificationsEmail.package }}"
@@ -301,10 +298,16 @@ data:
                    hostname: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.hostname }}
                    port: {{ .Values.rhdhPlugins.notificationsEmail.port }}
                    secure: false
+                {{- if .Values.rhdhOperator.secretRef.notificationsEmail.username }}
                    username: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.username }}
+                {{- end}}
+                {{- if .Values.rhdhOperator.secretRef.notificationsEmail.password }}
                    password: {{ printf "${%s}" .Values.rhdhOperator.secretRef.notificationsEmail.password }}
+                {{- end}}
                  sender: {{ .Values.rhdhPlugins.notificationsEmail.sender }}
+                {{- if .Values.rhdhPlugins.notificationsEmail.replyTo }}
                  replyTo: {{ .Values.rhdhPlugins.notificationsEmail.replyTo }}
+                {{- end}}
                  concurrencyLimit: 10
                  cache:
                    ttl:


### PR DESCRIPTION
Since the plugin doesn't require username and passowrd, the chart should respect that.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED