### PR TITLE
Split target namespace for RHDH instance from subscription ns

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc16
+version: 1.2.0-rc17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhOperator.subscription.name` | name of the operator package | `"rhdh"` |
 | `rhdhOperator.subscription.source` | name of the catalog source | `"redhat-operators"` |
 | `rhdhOperator.subscription.startingCSV` | The initial version of the operator | `""` |
+| `rhdhOperator.subscription.targetNamespace` | the target namespace for the backstage CR in which RHDH instance is created | `"rhdh-operator"` |
 | `rhdhPlugins.npmRegistry` | NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories | `"https://npm.stage.registry.redhat.com"` |
 | `rhdhPlugins.scope` |  | `"@redhat"` |
 | `rhdhPlugins.orchestrator.package` |  | `"backstage-plugin-orchestrator@1.1.0-rc.0-0"` |

--- a/charts/orchestrator/templates/NOTES.txt
+++ b/charts/orchestrator/templates/NOTES.txt
@@ -25,7 +25,7 @@ Helm Release {{ .Release.Name }} installed in namespace {{ .Release.Namespace }}
   {{- $backstageInstalled = $no}}
 {{- end }}
 
-{{- if and $backstageInstalled (lookup "apps/v1" "StatefulSet" .Values.rhdhOperator.subscription.namespace "backstage-psql-backstage" ) }}
+{{- if and $backstageInstalled (lookup "apps/v1" "StatefulSet" .Values.rhdhOperator.subscription.targetNamespace "backstage-psql-backstage" ) }}
   {{- $postgresBackstageInstalled = $yes }}
 {{- end }}
 
@@ -62,8 +62,8 @@ Helm Release {{ .Release.Name }} installed in namespace {{ .Release.Namespace }}
 
 Components                   Installed   Namespace
 ====================================================================
-Backstage                    {{ $backstageInstalled }}        {{ .Values.rhdhOperator.subscription.namespace }}
-Postgres DB - Backstage      {{ $postgresBackstageInstalled }}        {{ .Values.rhdhOperator.subscription.namespace }}
+Backstage                    {{ $backstageInstalled }}        {{ .Values.rhdhOperator.subscription.targetNamespace }}
+Postgres DB - Backstage      {{ $postgresBackstageInstalled }}        {{ .Values.rhdhOperator.subscription.targetNamespace }}
 Red Hat Serverless Operator  {{ $serverlessOperatorInstalled }}        {{ .Values.serverlessOperator.subscription.namespace }}
 KnativeServing               {{ $knativeServingInstalled }}        knative-serving
 KnativeEventing              {{ $knativeEventingInstalled }}        knative-eventing
@@ -118,11 +118,11 @@ Run the following commands to wait until the services are ready:
   oc wait -n {{ $workflowNamespace }} deploy/sonataflow-platform-jobs-service --for=condition=Available {{ $timeout }}
 {{- end }}
 {{- if eq $postgresBackstageInstalled $yes }}
-  oc wait -n {{ .Values.rhdhOperator.subscription.namespace }} pod/backstage-psql-backstage-0 --for=condition=Ready {{ $timeout }}
+  oc wait -n {{ .Values.rhdhOperator.subscription.targetNamespace }} pod/backstage-psql-backstage-0 --for=condition=Ready {{ $timeout }}
 {{- end }}
 {{- if eq $backstageInstalled $yes }}
-  oc wait -n {{ .Values.rhdhOperator.subscription.namespace }} backstage backstage --for=condition=Deployed=True
-  oc wait -n {{ .Values.rhdhOperator.subscription.namespace }} deploy/backstage-backstage --for=condition=Available {{ $timeout }}
+  oc wait -n {{ .Values.rhdhOperator.subscription.targetNamespace }} backstage backstage --for=condition=Deployed=True
+  oc wait -n {{ .Values.rhdhOperator.subscription.targetNamespace }} deploy/backstage-backstage --for=condition=Available {{ $timeout }}
 {{- end }}
 {{- if eq $sonataFlowPlatformInstalled $yes }}
   oc get networkpolicy -n {{ $workflowNamespace }}

--- a/charts/orchestrator/templates/network-policies.yaml
+++ b/charts/orchestrator/templates/network-policies.yaml
@@ -12,7 +12,7 @@ spec:
       - namespaceSelector:
           matchLabels:
             # Allow RHDH namespace to communicate with workflows and sonataflow services
-            kubernetes.io/metadata.name: {{ .Values.rhdhOperator.subscription.namespace }}
+            kubernetes.io/metadata.name: {{ .Values.rhdhOperator.subscription.targetNamespace }}
       - namespaceSelector:
           matchLabels:
             # Allow any other namespace the has workflows deployed because this is where

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -4,7 +4,7 @@ apiVersion: rhdh.redhat.com/v1alpha1
 kind: Backstage
 metadata:
   name: backstage
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  namespace: {{ .Values.rhdhOperator.subscription.targetNamespace }}
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name}}
 spec:
@@ -25,9 +25,9 @@ spec:
   {{- if not .Values.rhdhOperator.secretRef.name }}
     {{- fail "Backstage's secret name defined in 'rhdhOperator.secretRef.name' is required" }}
   {{- end }}
-  {{- $secret := lookup "v1" "Secret" .Values.rhdhOperator.subscription.namespace .Values.rhdhOperator.secretRef.name }}
+  {{- $secret := lookup "v1" "Secret" .Values.rhdhOperator.subscription.targetNamespace .Values.rhdhOperator.secretRef.name }}
   {{- if not $secret }}
-    {{- fail (printf "Secret %s not found in namespace %s" .Values.rhdhOperator.secretRef.name .Values.rhdhOperator.subscription.namespace ) }}
+    {{- fail (printf "Secret %s not found in namespace %s" .Values.rhdhOperator.secretRef.name .Values.rhdhOperator.subscription.targetNamespace ) }}
   {{- end }}
   {{ if not .Values.rhdhOperator.secretRef.backstage.backendSecret }}
     {{ fail printf "Backend secret key not defined in secret '%s' for Backstage. Please ensure that the value key 'rhdhOperator.secretRef.backstage.backendSecret' has been populated and the value matches the key in the secret" .Values.rhdhOperator.secretRef.name }}
@@ -63,7 +63,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: dynamic-plugins-npmrc
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  namespace: {{ .Values.rhdhOperator.subscription.targetNamespace }}
 type: Opaque
 stringData:
   .npmrc: |
@@ -74,12 +74,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: app-config-rhdh
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  namespace: {{ .Values.rhdhOperator.subscription.targetNamespace }}
 data:
   "app-config-rhdh.yaml": |
     app:
       title: Red Hat Developer Hub
-      baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.namespace }}.{{ include "cluster.domain" . }}
+      baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.targetNamespace }}.{{ include "cluster.domain" . }}
     backend:
       auth:
         externalAccess:
@@ -87,13 +87,13 @@ data:
             options:
               token: {{ printf "${%s}" .Values.rhdhOperator.secretRef.backstage.backendSecret }}
               subject: orchestrator
-      baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.namespace }}.{{ include "cluster.domain" . }}
+      baseUrl: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.targetNamespace }}.{{ include "cluster.domain" . }}
       csp:
         script-src: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
         script-src-elem: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
         connect-src: ["'self'", 'http:', 'https:', 'data:']
       cors:
-        origin: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.namespace }}.{{ include "cluster.domain" . }}
+        origin: https://backstage-backstage-{{ .Values.rhdhOperator.subscription.targetNamespace }}.{{ include "cluster.domain" . }}
       database:
         client: pg
         connection:
@@ -106,7 +106,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: dynamic-plugins-rhdh
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  namespace: {{ .Values.rhdhOperator.subscription.targetNamespace }}
 data:
   "dynamic-plugins.yaml": |
     includes:
@@ -318,7 +318,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-config-rhdh-auth
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  namespace: {{ .Values.rhdhOperator.subscription.targetNamespace }}
 data:
   app-config-auth.gh.yaml: |
   {{- if and .Values.rhdhOperator.secretRef.github.token (dig "data" .Values.rhdhOperator.secretRef.github.token "" $secret) }}
@@ -347,7 +347,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: app-config-rhdh-catalog
-  namespace: {{ .Values.rhdhOperator.subscription.namespace }}
+  namespace: {{ .Values.rhdhOperator.subscription.targetNamespace }}
 data:
   "app-config-catalog.yaml": |
     catalog:
@@ -376,7 +376,7 @@ data:
         - type: url
           target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/complex-assessment-workflow/template.yaml
 {{- end }}
-{{- $unmanagedNamespaceExists := include "unmanaged-resource-exists" (list "rhdh.redhat.com/v1alpha1" "Backstage" .Values.rhdhOperator.subscription.namespace "backstage" .Release.Name .Capabilities.APIVersions ) }}
+{{- $unmanagedNamespaceExists := include "unmanaged-resource-exists" (list "rhdh.redhat.com/v1alpha1" "Backstage" .Values.rhdhOperator.subscription.targetNamespace "backstage" .Release.Name .Capabilities.APIVersions ) }}
 {{- if eq $unmanagedNamespaceExists "false" }}
-  {{- include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "rhdh.redhat.com" "groupVersion" "v1alpha1" "kind" "Backstage" "kinds" "backstages" "targetNamespace" .Values.rhdhOperator.subscription.namespace "resourceName" "backstage" "isEnabled" .Values.rhdhOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "rhdh.redhat.com/v1alpha1/Backstage") "manifest" (include "backstage-manifest" . | b64enc )) }}
+  {{- include "manage-cr-lifecycle-on-action" (dict "release" .Release "apiGroup" "rhdh.redhat.com" "groupVersion" "v1alpha1" "kind" "Backstage" "kinds" "backstages" "targetNamespace" .Values.rhdhOperator.subscription.targetNamespace "resourceName" "backstage" "isEnabled" .Values.rhdhOperator.enabled "hasCRDInstalled" (.Capabilities.APIVersions.Has "rhdh.redhat.com/v1alpha1/Backstage") "manifest" (include "backstage-manifest" . | b64enc )) }}
 {{- end }}

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -485,7 +485,8 @@
                         "installPlanApproval",
                         "name",
                         "source",
-                        "startingCSV"
+                        "startingCSV",
+                        "targetNamespace"
                     ],
                     "properties": {
                         "namespace": {
@@ -535,6 +536,14 @@
                             "examples": [
                                 ""
                             ]
+                        },
+                        "targetNamespace": {
+                            "type": "string",
+                            "default": "",
+                            "title": "The targetNamespace Schema",
+                            "examples": [
+                                "rhdh-operator"
+                            ]
                         }
                     },
                     "examples": [{
@@ -543,7 +552,8 @@
                         "installPlanApproval": "Automatic",
                         "name": "rhdh",
                         "source": "redhat-operators",
-                        "startingCSV": ""
+                        "startingCSV": "",
+                        "targetNamespace": "rhdh-operator"
                     }]
                 }
             },
@@ -582,7 +592,8 @@
                     "installPlanApproval": "Automatic",
                     "name": "rhdh",
                     "source": "redhat-operators",
-                    "startingCSV": ""
+                    "startingCSV": "",
+                    "targetNamespace": "rhdh-operator"
                 }
             }]
         },
@@ -1251,7 +1262,8 @@
                 "installPlanApproval": "Automatic",
                 "name": "rhdh",
                 "source": "redhat-operators",
-                "startingCSV": ""
+                "startingCSV": "",
+                "targetNamespace": "rhdh-operator"
             }
         },
         "rhdhPlugins": {

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -49,6 +49,7 @@ rhdhOperator:
     name: rhdh # name of the operator package
     source: redhat-operators # name of the catalog source
     startingCSV: "" # The initial version of the operator
+    targetNamespace: rhdh-operator # the target namespace for the backstage CR in which RHDH instance is created
 
 rhdhPlugins: # RHDH plugins required for the Orchestrator
   npmRegistry: "https://npm.stage.registry.redhat.com" # NPM registry is defined already in the container, but sometimes the registry need to be modified to use different versions of the plugin, for example: staging(https://npm.stage.registry.redhat.com) or development repositories


### PR DESCRIPTION
The RHDH instance may be created in a different namespace than the one in which the RHDH operator is created. For that reason, a targetNamespace property is added to determine the target namespace for the RHDH instance created by the chart.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED