### PR TITLE
Add a variable for specify the software template branch

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0-rc19
+version: 1.2.0-rc20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/orchestrator/README.md
+++ b/charts/orchestrator/README.md
@@ -29,6 +29,7 @@ The following table lists the configurable parameters of the Orchestrator chart 
 | `rhdhOperator.isReleaseCandidate` | Indicates RC builds should be used by the chart to install RHDH | `false` |
 | `rhdhOperator.enabled` | whether the operator should be deployed by the chart | `true` |
 | `rhdhOperator.enableGuestProvider` | whether to enable guest provider | `false` |
+| `rhdhOperator.catalogBranch` | The branch for https://github.com/parodos-dev/workflow-software-templates used to import software templates resources | `"main"` |
 | `rhdhOperator.secretRef.name` | name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD, GitHub servers and SMTP mail server. | `"backstage-backend-auth-secret"` |
 | `rhdhOperator.secretRef.backstage.backendSecret` | Key in the secret with name defined in the 'name' field that contains the value of the Backstage backend secret. Defaults to 'BACKEND_SECRET'. It's required. | `"BACKEND_SECRET"` |
 | `rhdhOperator.secretRef.github.token` | Key in the secret with name defined in the 'name' field that contains the value of the authentication token as expected by GitHub. Required for importing resource to the catalog, launching software templates and more. Defaults to 'GITHUB_TOKEN', empty for not available. | `"GITHUB_TOKEN"` |

--- a/charts/orchestrator/templates/rhdh-operator.yaml
+++ b/charts/orchestrator/templates/rhdh-operator.yaml
@@ -347,11 +347,11 @@ data:
           target: https://github.com/parodos-dev/orchestrator-helm-chart/blob/main/resources/users.yaml
       {{- end }}
         - type: url
-          target: https://github.com/parodos-dev/workflow-software-templates/blob/main/entities/workflow-resources.yaml
+          target: https://github.com/parodos-dev/workflow-software-templates/{{ .Values.rhdhOperator.catalogBranch }}/main/entities/workflow-resources.yaml
         - type: url
-          target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/basic-workflow/template.yaml
+          target: https://github.com/parodos-dev/workflow-software-templates/blob/{{ .Values.rhdhOperator.catalogBranch }}/scaffolder-templates/basic-workflow/template.yaml
         - type: url
-          target: https://github.com/parodos-dev/workflow-software-templates/blob/main/scaffolder-templates/complex-assessment-workflow/template.yaml
+          target: https://github.com/parodos-dev/workflow-software-templates/blob/{{ .Values.rhdhOperator.catalogBranch }}/scaffolder-templates/complex-assessment-workflow/template.yaml
 {{- end }}
 {{- $unmanagedNamespaceExists := include "unmanaged-resource-exists" (list "rhdh.redhat.com/v1alpha1" "Backstage" .Values.rhdhOperator.subscription.targetNamespace "backstage" .Release.Name .Capabilities.APIVersions ) }}
 {{- if eq $unmanagedNamespaceExists "false" }}

--- a/charts/orchestrator/values.schema.json
+++ b/charts/orchestrator/values.schema.json
@@ -224,6 +224,7 @@
                 "isReleaseCandidate",
                 "enabled",
                 "enableGuestProvider",
+                "catalogBranch",
                 "secretRef",
                 "subscription"
             ],
@@ -250,6 +251,14 @@
                     "title": "The enableGuestProvider Schema",
                     "examples": [
                         false
+                    ]
+                },
+                "catalogBranch": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The catalogBranch Schema",
+                    "examples": [
+                        "main"
                     ]
                 },
                 "secretRef": {
@@ -561,6 +570,7 @@
                 "isReleaseCandidate": false,
                 "enabled": true,
                 "enableGuestProvider": false,
+                "catalogBranch": "main",
                 "secretRef": {
                     "name": "backstage-backend-auth-secret",
                     "backstage": {
@@ -1231,6 +1241,7 @@
             "isReleaseCandidate": false,
             "enabled": true,
             "enableGuestProvider": false,
+            "catalogBranch": "main",
             "secretRef": {
                 "name": "backstage-backend-auth-secret",
                 "backstage": {

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -22,6 +22,7 @@ rhdhOperator:
   isReleaseCandidate: false # Indicates RC builds should be used by the chart to install RHDH
   enabled: true # whether the operator should be deployed by the chart
   enableGuestProvider: false # whether to enable guest provider
+  catalogBranch: main # The branch for https://github.com/parodos-dev/workflow-software-templates used to import software templates resources
   secretRef:
     name: backstage-backend-auth-secret # name of the secret that contains the credentials for the plugin to establish a communication channel with the Kubernetes API, ArgoCD, GitHub servers and SMTP mail server.
     backstage:


### PR DESCRIPTION
It is common use case to refer a specific branch for importing the software templates from when developing features for the chart. Instead of manipulating the chart locally, a variable is expose to ease the experience when a different branch then the `main` is needed.

Another value for this variable is when releasing a version, in which case only the values.yaml will have to be modified.

Signed-off-by: Moti Asayag <masayag@redhat.com>

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED