### PR TITLE
Revert version bump for backstage-plugin-orchestrator* plugins

### DIFF
--- a/charts/orchestrator-k8s/values.yaml
+++ b/charts/orchestrator-k8s/values.yaml
@@ -29,8 +29,8 @@ backstage:
         - dynamic-plugins.default.yaml
       plugins:
         - disabled: false
-          package: "@janus-idp/backstage-plugin-orchestrator-backend-dynamic@1.22.2"
-          integrity: sha512-eaI6aAg8JAvNGwdTvXudoOKjfFnKygLScn6QP9hMvgt6pehtovYb1ZY/+nrym74Shl2OHEbygtxGQr8IH8z6fg==
+          package: "@janus-idp/backstage-plugin-orchestrator-backend-dynamic@1.21.0"
+          integrity: sha512-/g7pjYZmKXTalWQTH+L5w1Uu4xvKHe6G7RQd2chhP3Ey2opO+IHtz8TtrLa4fCeWxlrrVpfTI6PiXamTAO4zMg==
           pluginConfig:
             orchestrator:
               dataIndexService:
@@ -38,8 +38,8 @@ backstage:
               editor:
                 path: https://sandbox.kie.org/swf-chrome-extension/0.32.0
         - disabled: false
-          package: "@janus-idp/backstage-plugin-orchestrator@1.22.2"
-          integrity: sha512-BUxgmg+zT9eulBqWHQrgzfxVdAATRGMkW1CyILprCWCC3sED+f55QEXNp12xf9hnjSt6ERAU+uSJj0v4RZaAPA==
+          package: "@janus-idp/backstage-plugin-orchestrator@1.22.0"
+          integrity: sha512-7CAhoVgI2QTErPzZBHXb7OJp1R9c1qtljCF3I92o1ITrn81/3wy1VLMjVmjYK0QrvAkYM9aH/1izoZ4cayKbRw==
           pluginConfig:
             dynamicPlugins:
               frontend:


### PR DESCRIPTION
Revert version bump for backstage-plugin-orchestrator* plugins
The current versions  cause an error:
```
$ oc logs orchestrator-backstage-69db9f5867-sx8dt -f
Defaulted container "backstage-backend" out of: backstage-backend, install-dynamic-plugins (init)
Loading config from MergedConfigSource{FileConfigSource{path="/opt/app-root/src/app-config.yaml"}, FileConfigSource{path="/opt/app-root/src/app-config.example.yaml"}, FileConfigSource{path="/opt/app-root/src/app-config.example.production.yaml"}, FileConfigSource{path="/opt/app-root/src/dynamic-plugins-root/app-config.dynamic-plugins.yaml"}, FileConfigSource{path="/opt/app-root/src/app-config-from-configmap.yaml"}, EnvConfigSource{count=1}}
skipping '/opt/app-root/src/dynamic-plugins-root/app-config.dynamic-plugins.yaml' since it is not a directory
{"level":"info","message":"Found 4 new secrets in config that will be redacted","service":"backstage","timestamp":"2024-09-11 13:26:58"}
{"level":"info","message":"skipping '/opt/app-root/src/dynamic-plugins-root/app-config.dynamic-plugins.yaml' since it is not a directory","service":"backstage","timestamp":"2024-09-11 13:26:58"}
{"level":"info","message":"Resolving '@backstage/plugin-notifications-backend/package.json' in the dynamic backend plugins","service":"backstage","timestamp":"2024-09-11 13:26:58"}
{"level":"info","message":"Resolved '@backstage/plugin-notifications-backend/package.json' at /opt/app-root/src/dynamic-plugins-root/backstage-plugin-notifications-backend-dynamic-0.2.0/package.json","service":"backstage","timestamp":"2024-09-11 13:26:58"}
{"level":"info","message":"loaded dynamic backend plugin '@backstage/plugin-notifications-backend-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-notifications-backend-dynamic-0.2.0'","service":"backstage","timestamp":"2024-09-11 13:26:58"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-scaffolder-backend-module-azure-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-azure-dynamic-0.1.9'","service":"backstage","timestamp":"2024-09-11 13:26:58"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic-0.1.7'","service":"backstage","timestamp":"2024-09-11 13:26:59"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic-0.1.7'","service":"backstage","timestamp":"2024-09-11 13:26:59"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-scaffolder-backend-module-gerrit-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-gerrit-dynamic-0.1.9'","service":"backstage","timestamp":"2024-09-11 13:26:59"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-scaffolder-backend-module-github-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-github-dynamic-0.2.7'","service":"backstage","timestamp":"2024-09-11 13:26:59"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-scaffolder-backend-module-gitlab-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-gitlab-dynamic-0.3.3'","service":"backstage","timestamp":"2024-09-11 13:26:59"}
{"level":"info","message":"loaded dynamic backend plugin '@backstage/plugin-signals-backend-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-signals-backend-dynamic-0.1.3'","service":"backstage","timestamp":"2024-09-11 13:26:59"}
{"level":"info","message":"loaded dynamic backend plugin 'backstage-plugin-techdocs-backend-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-techdocs-backend-dynamic-1.10.4'","service":"backstage","timestamp":"2024-09-11 13:27:00"}
{"level":"info","message":"loaded dynamic backend plugin '@janus-idp/backstage-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic-1.0.3/alpha'","service":"backstage","timestamp":"2024-09-11 13:27:00"}
{"level":"info","message":"loaded dynamic backend plugin '@janus-idp/backstage-plugin-orchestrator-backend-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/alpha'","service":"backstage","timestamp":"2024-09-11 13:27:01"}
{"level":"info","message":"loaded dynamic backend plugin '@janus-idp/backstage-scaffolder-backend-module-quay-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-scaffolder-backend-module-quay-dynamic-1.4.12/alpha'","service":"backstage","timestamp":"2024-09-11 13:27:01"}
{"level":"info","message":"loaded dynamic backend plugin '@janus-idp/backstage-scaffolder-backend-module-regex-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-scaffolder-backend-module-regex-dynamic-1.4.12/alpha'","service":"backstage","timestamp":"2024-09-11 13:27:01"}
{"level":"info","message":"loaded dynamic backend plugin 'roadiehq-scaffolder-backend-module-http-request-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/roadiehq-scaffolder-backend-module-http-request-dynamic-4.3.2'","service":"backstage","timestamp":"2024-09-11 13:27:01"}
{"level":"info","message":"loaded dynamic backend plugin 'roadiehq-scaffolder-backend-module-utils-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/roadiehq-scaffolder-backend-module-utils-dynamic-1.15.3'","service":"backstage","timestamp":"2024-09-11 13:27:01"}
{"level":"info","message":"Listening on :7007","service":"rootHttpRouter","timestamp":"2024-09-11 13:27:01"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:01"}
{"level":"info","message":"Serving static app content from /opt/app-root/src/packages/app/dist","plugin":"app","service":"backstage","timestamp":"2024-09-11 13:27:02"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"info","message":"Performing database migration","plugin":"catalog","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"info","message":"[HPM] Proxy created: /quay/api  -> https://quay.io/","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"info","message":"[HPM] Proxy rewrite rule created: \"^/api/proxy/quay/api/?\" ~> \"/\"","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /sonarqube due to Proxy target for route \"/sonarqube\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /jenkins/api due to Proxy target for route \"/jenkins/api\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /jira/api due to Proxy target for route \"/jira/api\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /acr/api due to Proxy target for route \"/acr/api\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /jfrog-artifactory/api due to Proxy target for route \"/jfrog-artifactory/api\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"info","message":"[HPM] Proxy created: /pagerduty  -> https://api.pagerduty.com","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"info","message":"[HPM] Proxy rewrite rule created: \"^/api/proxy/pagerduty/?\" ~> \"/\"","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /dynatrace due to Proxy target for route \"/dynatrace\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"skipped configuring /nexus-repository-manager due to Proxy target for route \"/nexus-repository-manager\" must be a string, but is of type undefined","plugin":"proxy","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"entry":"main","level":"info","message":"Injecting env config into 1378.60fbd6e4.chunk.js","plugin":"app","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"info","message":"Starting scaffolder with the following actions enabled catalog:scaffolded-from, catalog:timestamping, catalog:annotate, quay:create-repository, regex:replace, publish:azure, publish:bitbucketCloud, bitbucket:pipelines:run, publish:bitbucketServer, publish:bitbucketServer:pull-request, publish:gerrit, publish:gerrit:review, github:actions:dispatch, github:autolinks:create, github:deployKey:create, github:environment:create, github:issues:label, github:repo:create, github:repo:push, github:webhook, publish:github, publish:github:pull-request, gitlab:group:ensureExists, gitlab:issues:create, gitlab:projectAccessToken:create, gitlab:projectDeployToken:create, gitlab:projectVariable:create, gitlab:repo:push, publish:gitlab, publish:gitlab:merge-request, http:backstage:request, roadiehq:utils:zip, roadiehq:utils:sleep, roadiehq:utils:fs:write, roadiehq:utils:fs:append, roadiehq:utils:json:merge, roadiehq:utils:merge, roadiehq:utils:fs:parse, roadiehq:utils:fs:replace, roadiehq:utils:serialize:yaml, roadiehq:utils:serialize:json, roadiehq:utils:jsonata, roadiehq:utils:jsonata:yaml:transform, roadiehq:utils:jsonata:json:transform, fetch:plain, fetch:plain:file, fetch:template, debug:log, debug:wait, catalog:register, catalog:fetch, catalog:write, fs:delete, fs:rename","plugin":"scaffolder","service":"backstage","timestamp":"2024-09-11 13:27:03"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Added DefaultCatalogCollatorFactory collator factory for type software-catalog","plugin":"search","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Added DefaultTechDocsCollatorFactory collator factory for type techdocs","plugin":"search","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Starting all scheduled search tasks.","plugin":"search","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Storing 313 updated assets and 0 new assets","plugin":"app","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Task worker starting: search_index_software_catalog, {\"version\":2,\"cadence\":\"PT10M\",\"initialDelayDuration\":\"PT3S\",\"timeoutAfterDuration\":\"PT15M\"}","plugin":"search","service":"backstage","task":"search_index_software_catalog","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Task worker starting: search_index_techdocs, {\"version\":2,\"cadence\":\"PT10M\",\"initialDelayDuration\":\"PT3S\",\"timeoutAfterDuration\":\"PT15M\"}","plugin":"search","service":"backstage","task":"search_index_techdocs","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"RBAC backend plugin was disabled by application config permission.enabled: false","plugin":"permission","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"You should NOT be using the guest provider outside of a development environment.","plugin":"auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Enabled Provider Factories : {}","plugin":"auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Configuring \"database\" as KeyStore provider","plugin":"auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Configuring auth provider: guest","plugin":"auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"info","message":"Configuring auth provider: github","plugin":"auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:04"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Loaded dynamic frontend plugin '@backstage/plugin-notifications-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-notifications-dynamic-0.2.0' ","plugin":"scalprum","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Loaded dynamic frontend plugin '@backstage/plugin-signals-dynamic' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-signals-dynamic-0.0.5' ","plugin":"scalprum","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Loaded dynamic frontend plugin 'backstage-plugin-techdocs' from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-techdocs-1.10.4' ","plugin":"scalprum","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Loaded dynamic frontend plugin '@janus-idp/backstage-plugin-analytics-provider-segment' from 'file:///opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-analytics-provider-segment-1.4.9' ","plugin":"scalprum","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Loaded dynamic frontend plugin '@janus-idp/backstage-plugin-orchestrator' from 'file:///opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-1.22.0' ","plugin":"scalprum","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Creating Local publisher for TechDocs","plugin":"techdocs","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Resolving '@backstage/plugin-techdocs-backend/package.json' in the dynamic backend plugins","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"warn","message":"DEPRECATION WARNING: The backend.auth.keys config has been replaced by backend.auth.externalAccess, see https://backstage.io/docs/auth/service-to-service-auth","service":"backstage","timestamp":"2024-09-11 13:27:05"}
{"level":"info","message":"Resolving '@janus-idp/backstage-plugin-orchestrator-backend/package.json' in the dynamic backend plugins","service":"backstage","timestamp":"2024-09-11 13:27:06"}
{"level":"info","message":"Resolved '@janus-idp/backstage-plugin-orchestrator-backend/package.json' at /opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/package.json","service":"backstage","timestamp":"2024-09-11 13:27:06"}
{"level":"info","message":"Resolving '@janus-idp/backstage-plugin-orchestrator-common/package.json' in the dynamic backend plugins","service":"backstage","timestamp":"2024-09-11 13:27:06"}
{"code":"MODULE_NOT_FOUND","level":"error","message":"Error when resolving '@janus-idp/backstage-plugin-orchestrator-common' with search path: '[/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-1.22.0/node_modules]' Cannot find module '@janus-idp/backstage-plugin-orchestrator-common/package.json'\nRequire stack:\n- /opt/app-root/src/packages/backend/dist/index.cjs.js","requireStack":["/opt/app-root/src/packages/backend/dist/index.cjs.js"],"service":"backstage","stack":"Error: Cannot find module '@janus-idp/backstage-plugin-orchestrator-common/package.json'\nRequire stack:\n- /opt/app-root/src/packages/backend/dist/index.cjs.js\n    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)\n    at ModuleObject._resolveFilename (/opt/app-root/src/packages/backend/dist/index.cjs.js:78:16)\n    at Function.resolve (node:internal/modules/helpers:190:19)\n    at ModuleObject._resolveFilename (/opt/app-root/src/packages/backend/dist/index.cjs.js:111:42)\n    at Function.resolve (node:internal/modules/helpers:190:19)\n    at Object.resolvePackagePath (/opt/app-root/src/node_modules/@backstage/backend-common/dist/cjs/paths-Cebs5I6U.cjs.js:18:35)\n    at createBackendRouter (/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/dist/cjs/index-7a61ecd9.cjs.js:1751:21)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Object.createRouter (/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/dist/cjs/index-7a61ecd9.cjs.js:2441:10)\n    at async Object.init [as func] (/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/dist/alpha.cjs.js:58:24)\n    at async /opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1805:9\n    at async Promise.all (index 13)\n    at async BackendInitializer.doStart_fn (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1766:3)\n    at async BackendInitializer.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1626:5)\n    at async BackstageBackend.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1894:5)","timestamp":"2024-09-11 13:27:06"}
/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1806
          throw new errors.ForwardedError(
                ^

ForwardedError: Plugin 'orchestrator' startup failed; caused by Error: Cannot find module '@janus-idp/backstage-plugin-orchestrator-common/package.json'
Require stack:
- /opt/app-root/src/node_modules/@backstage/backend-common/dist/cjs/paths-Cebs5I6U.cjs.js
- /opt/app-root/src/node_modules/@backstage/backend-common/dist/index.cjs.js
- /opt/app-root/src/packages/backend/node_modules/@backstage/backend-app-api/dist/index.cjs.js
- /opt/app-root/src/packages/backend/dist/index.cjs.js
    at /opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1806:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1805:9
    ... 3 lines matching cause stack trace ...
    at async BackstageBackend.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1894:5) {
  cause: Error: Cannot find module '@janus-idp/backstage-plugin-orchestrator-common/package.json'
  Require stack:
  - /opt/app-root/src/node_modules/@backstage/backend-common/dist/cjs/paths-Cebs5I6U.cjs.js
  - /opt/app-root/src/node_modules/@backstage/backend-common/dist/index.cjs.js
  - /opt/app-root/src/packages/backend/node_modules/@backstage/backend-app-api/dist/index.cjs.js
  - /opt/app-root/src/packages/backend/dist/index.cjs.js
      at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
      at ModuleObject._resolveFilename (/opt/app-root/src/packages/backend/dist/index.cjs.js:78:16)
      at Function.resolve (node:internal/modules/helpers:190:19)
      at Object.resolvePackagePath (/opt/app-root/src/node_modules/@backstage/backend-common/dist/cjs/paths-Cebs5I6U.cjs.js:18:35)
      at createBackendRouter (/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/dist/cjs/index-7a61ecd9.cjs.js:1751:21)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Object.createRouter (/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/dist/cjs/index-7a61ecd9.cjs.js:2441:10)
      at async Object.init [as func] (/opt/app-root/src/dynamic-plugins-root/janus-idp-backstage-plugin-orchestrator-backend-dynamic-1.22.2/dist/alpha.cjs.js:58:24)
      at async /opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1805:9
      at async Promise.all (index 13)
      at async BackendInitializer.doStart_fn (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1766:3)
      at async BackendInitializer.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1626:5)
      at async BackstageBackend.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1894:5) {
    code: 'MODULE_NOT_FOUND',
    requireStack: [
      '/opt/app-root/src/node_modules/@backstage/backend-common/dist/cjs/paths-Cebs5I6U.cjs.js',
      '/opt/app-root/src/node_modules/@backstage/backend-common/dist/index.cjs.js',
      '/opt/app-root/src/packages/backend/node_modules/@backstage/backend-app-api/dist/index.cjs.js',
      '/opt/app-root/src/packages/backend/dist/index.cjs.js'
    ]
  }
}

Node.js v20.16.0
```